### PR TITLE
Replace yarp::os::ConstString with const std::string in hand-tracking module

### DIFF
--- a/src/hand-tracking/include/GatePose.h
+++ b/src/hand-tracking/include/GatePose.h
@@ -1,8 +1,6 @@
 #ifndef GATEPOSE_H
 #define GATEPOSE_H
 
-#include <string>
-
 #include <BayesFilters/PFCorrectionDecorator.h>
 #include <BayesFilters/StateModel.h>
 

--- a/src/hand-tracking/include/InitPoseParticles.h
+++ b/src/hand-tracking/include/InitPoseParticles.h
@@ -6,7 +6,6 @@
 #include <iCub/iKin/iKinFwd.h>
 #include <yarp/os/Bottle.h>
 #include <yarp/os/BufferedPort.h>
-#include <yarp/os/ConstString.h>
 #include <yarp/sig/Vector.h>
 
 

--- a/src/hand-tracking/include/InitWalkmanArm.h
+++ b/src/hand-tracking/include/InitWalkmanArm.h
@@ -5,17 +5,18 @@
 
 #include <yarp/os/Bottle.h>
 #include <yarp/os/BufferedPort.h>
-#include <yarp/os/ConstString.h>
 #include <yarp/sig/Vector.h>
+
+#include <string>
 
 
 class InitWalkmanArm : public InitPoseParticles
 {
 public:
-    InitWalkmanArm(const yarp::os::ConstString& cam_sel, const yarp::os::ConstString& laterality,
-                   const yarp::os::ConstString& port_prefix) noexcept;
+    InitWalkmanArm(const std::string& cam_sel, const std::string& laterality,
+                   const std::string& port_prefix) noexcept;
 
-    InitWalkmanArm(const yarp::os::ConstString& cam_sel, const yarp::os::ConstString& laterality) noexcept;
+    InitWalkmanArm(const std::string& cam_sel, const std::string& laterality) noexcept;
 
     ~InitWalkmanArm() noexcept;
 
@@ -23,9 +24,9 @@ protected:
     Eigen::VectorXd readPose() override;
 
 private:
-    const yarp::os::ConstString  log_ID_ = "[InitWalkmanArm]";
+    const std::string  log_ID_ = "[InitWalkmanArm]";
 
-    yarp::os::ConstString port_prefix_;
+    const std::string port_prefix_;
 
     yarp::os::BufferedPort<yarp::os::Bottle> port_arm_pose_;
 

--- a/src/hand-tracking/include/InitiCubArm.h
+++ b/src/hand-tracking/include/InitiCubArm.h
@@ -6,17 +6,18 @@
 #include <iCub/iKin/iKinFwd.h>
 #include <yarp/os/Bottle.h>
 #include <yarp/os/BufferedPort.h>
-#include <yarp/os/ConstString.h>
 #include <yarp/sig/Vector.h>
+
+#include <string>
 
 
 class InitiCubArm : public InitPoseParticles
 {
 public:
-    InitiCubArm(const yarp::os::ConstString& cam_sel, const yarp::os::ConstString& laterality,
-                const yarp::os::ConstString& port_prefix) noexcept;
+    InitiCubArm(const std::string& cam_sel, const std::string& laterality,
+                const std::string& port_prefix) noexcept;
 
-    InitiCubArm(const yarp::os::ConstString& cam_sel, const yarp::os::ConstString& laterality) noexcept;
+    InitiCubArm(const std::string& cam_sel, const std::string& laterality) noexcept;
 
     ~InitiCubArm() noexcept;
 
@@ -24,9 +25,9 @@ protected:
     Eigen::VectorXd readPose() override;
 
 private:
-    const yarp::os::ConstString  log_ID_ = "[InitiCubArm]";
+    const std::string  log_ID_ = "[InitiCubArm]";
 
-    yarp::os::ConstString port_prefix_;
+    const std::string port_prefix_;
 
     iCub::iKin::iCubArm                      icub_kin_arm_;
 

--- a/src/hand-tracking/include/KinPoseModel.h
+++ b/src/hand-tracking/include/KinPoseModel.h
@@ -5,7 +5,6 @@
 #include <iCub/iKin/iKinFwd.h>
 #include <yarp/dev/PolyDriver.h>
 #include <yarp/dev/IEncoders.h>
-#include <yarp/os/ConstString.h>
 #include <yarp/sig/Vector.h>
 
 

--- a/src/hand-tracking/include/PlayGatePose.h
+++ b/src/hand-tracking/include/PlayGatePose.h
@@ -17,12 +17,12 @@ public:
                  const double gate_x, const double gate_y, const double gate_z,
                  const double gate_aperture,
                  const double gate_rotation,
-                 const yarp::os::ConstString& robot, const yarp::os::ConstString& laterality,
-                 const yarp::os::ConstString& port_prefix) noexcept;
+                 const std::string& robot, const std::string& laterality,
+                 const std::string& port_prefix) noexcept;
 
     PlayGatePose(std::unique_ptr<PFCorrection> visual_correction,
-                 const yarp::os::ConstString& robot, const yarp::os::ConstString& laterality,
-                 const yarp::os::ConstString& port_prefix) noexcept;
+                 const std::string& robot, const std::string& laterality,
+                 const std::string& port_prefix) noexcept;
 
     /* Destructor */
     ~PlayGatePose() noexcept override;
@@ -41,13 +41,13 @@ protected:
     yarp::sig::Vector readTorso();
 
 private:
-    const yarp::os::ConstString log_ID_ = "[PlayGatePose]";
+    const std::string log_ID_ = "[PlayGatePose]";
 
-    yarp::os::ConstString port_prefix_ = "PlayGatePose";
+    const std::string port_prefix_ = "PlayGatePose";
 
-    yarp::os::ConstString robot_;
+    const std::string robot_;
 
-    yarp::os::ConstString laterality_;
+    const std::string laterality_;
 };
 
 #endif /* PLAYGATEPOSE_H */

--- a/src/hand-tracking/include/PlayWalkmanPoseModel.h
+++ b/src/hand-tracking/include/PlayWalkmanPoseModel.h
@@ -6,14 +6,15 @@
 #include <iCub/iKin/iKinFwd.h>
 #include <yarp/os/Bottle.h>
 #include <yarp/os/BufferedPort.h>
-#include <yarp/os/ConstString.h>
 #include <yarp/sig/Vector.h>
+
+#include <string>
 
 
 class PlayWalkmanPoseModel : public KinPoseModel
 {
 public:
-    PlayWalkmanPoseModel(const yarp::os::ConstString& robot, const yarp::os::ConstString& laterality, const yarp::os::ConstString& port_prefix) noexcept;
+    PlayWalkmanPoseModel(const std::string& robot, const std::string& laterality, const std::string& port_prefix) noexcept;
 
     ~PlayWalkmanPoseModel() noexcept;
 
@@ -27,13 +28,13 @@ protected:
     yarp::os::BufferedPort<yarp::os::Bottle> port_arm_pose_;
 
 private:
-    const yarp::os::ConstString log_ID_ = "[PlayWalkmanPoseModel]";
+    const std::string log_ID_ = "[PlayWalkmanPoseModel]";
 
-    yarp::os::ConstString port_prefix_ = "PlayWalkmanPoseModel";
+    const std::string port_prefix_ = "PlayWalkmanPoseModel";
 
-    yarp::os::ConstString robot_;
+    const std::string robot_;
 
-    yarp::os::ConstString laterality_;
+    const std::string laterality_;
 };
 
 #endif /* PLAYWALKMANPOSEMODEL_H */

--- a/src/hand-tracking/include/PlayiCubFwdKinModel.h
+++ b/src/hand-tracking/include/PlayiCubFwdKinModel.h
@@ -6,14 +6,15 @@
 #include <iCub/iKin/iKinFwd.h>
 #include <yarp/os/Bottle.h>
 #include <yarp/os/BufferedPort.h>
-#include <yarp/os/ConstString.h>
 #include <yarp/sig/Vector.h>
+
+#include <string>
 
 
 class PlayiCubFwdKinModel : public KinPoseModel
 {
 public:
-    PlayiCubFwdKinModel(const yarp::os::ConstString& robot, const yarp::os::ConstString& laterality, const yarp::os::ConstString& port_prefix) noexcept;
+    PlayiCubFwdKinModel(const std::string& robot, const std::string& laterality, const std::string& port_prefix) noexcept;
 
     ~PlayiCubFwdKinModel() noexcept;
 
@@ -33,13 +34,13 @@ protected:
     iCub::iKin::iCubArm icub_kin_arm_;
 
 private:
-    const yarp::os::ConstString log_ID_ = "[PlayiCubFwdKinModel]";
+    const std::string log_ID_ = "[PlayiCubFwdKinModel]";
 
-    yarp::os::ConstString port_prefix_ = "PlayiCubFwdKinModel";
+    const std::string port_prefix_ = "PlayiCubFwdKinModel";
 
-    yarp::os::ConstString robot_;
+    const std::string robot_;
 
-    yarp::os::ConstString laterality_;
+    const std::string laterality_;
 };
 
 #endif /* PLAYICUBFWDKINMODEL_H */

--- a/src/hand-tracking/include/WalkmanArmModel.h
+++ b/src/hand-tracking/include/WalkmanArmModel.h
@@ -5,16 +5,17 @@
 
 #include <yarp/os/Bottle.h>
 #include <yarp/os/BufferedPort.h>
-#include <yarp/os/ConstString.h>
 #include <yarp/sig/Matrix.h>
+
+#include <string>
 
 
 class WalkmanArmModel : public bfl::MeshModel
 {
 public:
-    WalkmanArmModel(const yarp::os::ConstString& laterality,
-                    const yarp::os::ConstString& context,
-                    const yarp::os::ConstString& port_prefix);
+    WalkmanArmModel(const std::string& laterality,
+                    const std::string& context,
+                    const std::string& port_prefix);
 
     virtual ~WalkmanArmModel() noexcept { };
 
@@ -25,16 +26,16 @@ public:
     std::tuple<bool, std::vector<Superimpose::ModelPoseContainer>> getModelPose(const Eigen::Ref<const Eigen::MatrixXf>& cur_states);
 
 protected:
-    bool file_found(const yarp::os::ConstString& file);
+    bool file_found(const std::string& file);
 
 private:
-    const yarp::os::ConstString log_ID_ = "[WalkmanArmModel]";
+    const std::string log_ID_ = "[WalkmanArmModel]";
 
-    yarp::os::ConstString port_prefix_ = "WalkmanArmModel";
+    const std::string port_prefix_ = "WalkmanArmModel";
 
-    yarp::os::ConstString laterality_;
+    const std::string laterality_;
 
-    yarp::os::ConstString context_;
+    const std::string context_;
 
     SICAD::ModelPathContainer model_path_;
 

--- a/src/hand-tracking/include/iCubArmModel.h
+++ b/src/hand-tracking/include/iCubArmModel.h
@@ -15,9 +15,9 @@ class iCubArmModel : public bfl::MeshModel
 public:
     iCubArmModel(const bool use_thumb,
                  const bool use_forearm,
-                 const yarp::os::ConstString& laterality,
-                 const yarp::os::ConstString& context,
-                 const yarp::os::ConstString& port_prefix);
+                 const std::string& laterality,
+                 const std::string& context,
+                 const std::string& port_prefix);
 
     virtual ~iCubArmModel() noexcept;
 
@@ -28,7 +28,7 @@ public:
     std::tuple<bool, std::vector<Superimpose::ModelPoseContainer>> getModelPose(const Eigen::Ref<const Eigen::MatrixXf>& cur_states);
 
 protected:
-    bool file_found(const yarp::os::ConstString& file);
+    bool file_found(const std::string& file);
 
     yarp::sig::Matrix getInvertedH(const double a, const double d, const double alpha, const double offset, const double q);
 
@@ -37,17 +37,17 @@ protected:
     bool setArmJoints(const yarp::sig::Vector& q);
 
 private:
-    const yarp::os::ConstString log_ID_ = "[iCubArmModel]";
+    const std::string log_ID_ = "[iCubArmModel]";
 
-    yarp::os::ConstString port_prefix_ = "iCubArmModel";
+    const std::string port_prefix_ = "iCubArmModel";
 
     const bool use_thumb_;
 
     const bool use_forearm_;
 
-    yarp::os::ConstString laterality_;
+    const std::string laterality_;
 
-    yarp::os::ConstString context_;
+    const std::string context_;
 
     SICAD::ModelPathContainer model_path_;
 

--- a/src/hand-tracking/include/iCubCamera.h
+++ b/src/hand-tracking/include/iCubCamera.h
@@ -17,10 +17,10 @@
 class iCubCamera : public bfl::Camera
 {
 public:
-    iCubCamera(const yarp::os::ConstString& cam_sel,
+    iCubCamera(const std::string& cam_sel,
                const double resolution_ratio,
-               const yarp::os::ConstString& context,
-               const yarp::os::ConstString& port_prefix);
+               const std::string& context,
+               const std::string& port_prefix);
 
     virtual ~iCubCamera() noexcept;
 
@@ -44,15 +44,15 @@ protected:
     std::tuple<bool, yarp::sig::Vector> readRootToEye();
 
 private:
-    const yarp::os::ConstString log_ID_ = "[iCubCamera]";
+    const std::string log_ID_ = "[iCubCamera]";
 
-    yarp::os::ConstString port_prefix_ = "iCubCamera";
+    const std::string port_prefix_ = "iCubCamera";
 
-    yarp::os::ConstString cam_sel_;
+    const std::string cam_sel_;
 
     const double resolution_ratio_;
 
-    yarp::os::ConstString context_;
+    const std::string context_;
 
     yarp::dev::PolyDriver drv_gaze_;
 

--- a/src/hand-tracking/include/iCubFwdKinModel.h
+++ b/src/hand-tracking/include/iCubFwdKinModel.h
@@ -6,14 +6,15 @@
 #include <iCub/iKin/iKinFwd.h>
 #include <yarp/dev/PolyDriver.h>
 #include <yarp/dev/IEncoders.h>
-#include <yarp/os/ConstString.h>
 #include <yarp/sig/Vector.h>
+
+#include <string>
 
 
 class iCubFwdKinModel : public KinPoseModel
 {
 public:
-    iCubFwdKinModel(const yarp::os::ConstString& robot, const yarp::os::ConstString& laterality, const yarp::os::ConstString& port_prefix);
+    iCubFwdKinModel(const std::string& robot, const std::string& laterality, const std::string& port_prefix);
 
     ~iCubFwdKinModel() noexcept;
 
@@ -37,13 +38,13 @@ protected:
     iCub::iKin::iCubArm    icub_kin_arm_;
 
 private:
-    const yarp::os::ConstString  log_ID_ = "[iCubFwdKinModel]";
+    const std::string  log_ID_ = "[iCubFwdKinModel]";
 
-    yarp::os::ConstString  port_prefix_ = "iCubFwdKinModel";
+    const std::string  port_prefix_ = "iCubFwdKinModel";
 
-    yarp::os::ConstString  robot_;
+    const std::string  robot_;
 
-    yarp::os::ConstString  laterality_;
+    const std::string  laterality_;
 };
 
 #endif /* ICUBFWDKINMODEL_H */

--- a/src/hand-tracking/include/iCubGatePose.h
+++ b/src/hand-tracking/include/iCubGatePose.h
@@ -6,8 +6,9 @@
 #include <iCub/iKin/iKinFwd.h>
 #include <yarp/dev/IEncoders.h>
 #include <yarp/dev/PolyDriver.h>
-#include <yarp/os/ConstString.h>
 #include <yarp/sig/Vector.h>
+
+#include <string>
 
 
 class iCubGatePose : public GatePose

--- a/src/hand-tracking/src/InitWalkmanArm.cpp
+++ b/src/hand-tracking/src/InitWalkmanArm.cpp
@@ -12,15 +12,15 @@ using namespace yarp::sig;
 using namespace yarp::os;
 
 
-InitWalkmanArm::InitWalkmanArm(const ConstString& cam_sel, const ConstString& laterality,
-                               const ConstString& port_prefix) noexcept :
+InitWalkmanArm::InitWalkmanArm(const std::string& cam_sel, const std::string& laterality,
+                               const std::string& port_prefix) noexcept :
     port_prefix_(port_prefix)
 {
     port_arm_pose_.open("/" + port_prefix_ + "/" + laterality + "_arm:i");
 }
 
 
-InitWalkmanArm::InitWalkmanArm(const ConstString& cam_sel, const ConstString& laterality) noexcept :
+InitWalkmanArm::InitWalkmanArm(const std::string& cam_sel, const std::string& laterality) noexcept :
     InitWalkmanArm("InitWalkmanArm", cam_sel, laterality) { }
 
 

--- a/src/hand-tracking/src/InitiCubArm.cpp
+++ b/src/hand-tracking/src/InitiCubArm.cpp
@@ -12,8 +12,8 @@ using namespace yarp::sig;
 using namespace yarp::os;
 
 
-InitiCubArm::InitiCubArm(const ConstString& cam_sel, const ConstString& laterality,
-                         const ConstString& port_prefix) noexcept :
+InitiCubArm::InitiCubArm(const std::string& cam_sel, const std::string& laterality,
+                         const std::string& port_prefix) noexcept :
     port_prefix_(port_prefix),
     icub_kin_arm_(iCubArm(laterality + "_v2"))
 {
@@ -27,7 +27,7 @@ InitiCubArm::InitiCubArm(const ConstString& cam_sel, const ConstString& laterali
 }
 
 
-InitiCubArm::InitiCubArm(const ConstString& cam_sel, const ConstString& laterality) noexcept :
+InitiCubArm::InitiCubArm(const std::string& cam_sel, const std::string& laterality) noexcept :
     InitiCubArm("InitiCubArm", cam_sel, laterality) { }
 
 

--- a/src/hand-tracking/src/PlayGatePose.cpp
+++ b/src/hand-tracking/src/PlayGatePose.cpp
@@ -19,8 +19,8 @@ PlayGatePose::PlayGatePose(std::unique_ptr<PFCorrection> visual_correction,
                            const double gate_x, const double gate_y, const double gate_z,
                            const double gate_rotation,
                            const double gate_aperture,
-                           const yarp::os::ConstString& robot, const yarp::os::ConstString& laterality,
-                           const yarp::os::ConstString& port_prefix) noexcept :
+                           const std::string& robot, const std::string& laterality,
+                           const std::string& port_prefix) noexcept :
     GatePose(std::move(visual_correction),
              gate_x, gate_y, gate_z,
              gate_rotation,
@@ -45,8 +45,8 @@ PlayGatePose::PlayGatePose(std::unique_ptr<PFCorrection> visual_correction,
 
 
 PlayGatePose::PlayGatePose(std::unique_ptr<PFCorrection> visual_correction,
-                           const yarp::os::ConstString& robot, const yarp::os::ConstString& laterality,
-                           const yarp::os::ConstString& port_prefix) noexcept :
+                           const std::string& robot, const std::string& laterality,
+                           const std::string& port_prefix) noexcept :
     PlayGatePose(std::move(visual_correction), 0.1, 0.1, 0.1, 5, 30, robot, laterality, port_prefix) { }
 
 

--- a/src/hand-tracking/src/PlayWalkmanPoseModel.cpp
+++ b/src/hand-tracking/src/PlayWalkmanPoseModel.cpp
@@ -20,7 +20,7 @@ using namespace yarp::os;
 using namespace yarp::sig;
 
 
-PlayWalkmanPoseModel::PlayWalkmanPoseModel(const ConstString& robot, const ConstString& laterality, const ConstString& port_prefix) noexcept :
+PlayWalkmanPoseModel::PlayWalkmanPoseModel(const std::string& robot, const std::string& laterality, const std::string& port_prefix) noexcept :
     port_prefix_(port_prefix),
     robot_(robot),
     laterality_(laterality)

--- a/src/hand-tracking/src/PlayiCubFwdKinModel.cpp
+++ b/src/hand-tracking/src/PlayiCubFwdKinModel.cpp
@@ -20,7 +20,7 @@ using namespace yarp::os;
 using namespace yarp::sig;
 
 
-PlayiCubFwdKinModel::PlayiCubFwdKinModel(const ConstString& robot, const ConstString& laterality, const ConstString& port_prefix) noexcept :
+PlayiCubFwdKinModel::PlayiCubFwdKinModel(const std::string& robot, const std::string& laterality, const std::string& port_prefix) noexcept :
     icub_kin_arm_(iCubArm(laterality+"_v2")),
     port_prefix_(port_prefix),
     robot_(robot),

--- a/src/hand-tracking/src/WalkmanArmModel.cpp
+++ b/src/hand-tracking/src/WalkmanArmModel.cpp
@@ -14,9 +14,9 @@ using namespace yarp::os;
 using namespace yarp::sig;
 
 
-WalkmanArmModel::WalkmanArmModel(const ConstString& laterality,
-                                 const ConstString& context,
-                                 const yarp::os::ConstString& port_prefix) :
+WalkmanArmModel::WalkmanArmModel(const std::string& laterality,
+                                 const std::string& context,
+                                 const std::string& port_prefix) :
     port_prefix_(port_prefix),
     laterality_(laterality),
     context_(context)
@@ -90,7 +90,7 @@ std::tuple<bool, std::vector<Superimpose::ModelPoseContainer>> WalkmanArmModel::
 }
 
 
-bool WalkmanArmModel::file_found(const ConstString& file)
+bool WalkmanArmModel::file_found(const std::string& file)
 {
     if (!file.empty())
     {

--- a/src/hand-tracking/src/iCubArmModel.cpp
+++ b/src/hand-tracking/src/iCubArmModel.cpp
@@ -15,9 +15,9 @@ using namespace yarp::sig;
 
 iCubArmModel::iCubArmModel(const bool use_thumb,
                            const bool use_forearm,
-                           const ConstString& laterality,
-                           const ConstString& context,
-                           const yarp::os::ConstString& port_prefix) :
+                           const std::string& laterality,
+                           const std::string& context,
+                           const std::string& port_prefix) :
     port_prefix_(port_prefix),
     use_thumb_(use_thumb),
     use_forearm_(use_forearm),
@@ -280,7 +280,7 @@ std::tuple<bool, std::vector<Superimpose::ModelPoseContainer>> iCubArmModel::get
 }
 
 
-bool iCubArmModel::file_found(const ConstString& file)
+bool iCubArmModel::file_found(const std::string& file)
 {
     if (!file.empty())
     {

--- a/src/hand-tracking/src/iCubCamera.cpp
+++ b/src/hand-tracking/src/iCubCamera.cpp
@@ -19,10 +19,10 @@ using namespace yarp::sig;
 
 iCubCamera::iCubCamera
 (
-    const yarp::os::ConstString& cam_sel,
+    const std::string& cam_sel,
     const double resolution_ratio,
-    const yarp::os::ConstString& context,
-    const yarp::os::ConstString& port_prefix
+    const std::string& context,
+    const std::string& port_prefix
  ) :
     port_prefix_(port_prefix),
     cam_sel_(cam_sel),

--- a/src/hand-tracking/src/iCubFwdKinModel.cpp
+++ b/src/hand-tracking/src/iCubFwdKinModel.cpp
@@ -20,7 +20,7 @@ using namespace yarp::os;
 using namespace yarp::sig;
 
 
-iCubFwdKinModel::iCubFwdKinModel(const ConstString& robot, const ConstString& laterality, const ConstString& port_prefix) :
+iCubFwdKinModel::iCubFwdKinModel(const std::string& robot, const std::string& laterality, const std::string& port_prefix) :
     icub_kin_arm_(iCubArm(laterality+"_v2")),
     port_prefix_(port_prefix),
     robot_(robot),

--- a/src/hand-tracking/src/main.cpp
+++ b/src/hand-tracking/src/main.cpp
@@ -2,10 +2,10 @@
 #include <future>
 #include <iostream>
 #include <memory>
+#include <string>
 
 #include <BayesFilters/ResamplingWithPrior.h>
 #include <BayesFilters/UpdateParticles.h>
-#include <yarp/os/ConstString.h>
 #include <yarp/os/LogStream.h>
 #include <yarp/os/Network.h>
 #include <yarp/os/ResourceFinder.h>
@@ -45,7 +45,7 @@ using namespace yarp::os;
 /* MAIN */
 int main(int argc, char *argv[])
 {
-    ConstString log_ID = "[Main]";
+    const std::string log_ID = "[Main]";
     yInfo() << log_ID << "Configuring and starting module...";
 
     Network yarp;


### PR DESCRIPTION
This PR removes occurrences of `yarp::os::ConstString`, that is deprecated, in the code of the module `hand-tracking` and replaces them with `const std::string`.