### PR TITLE
Update hand-tracking module to BayesFilters 0.9.100

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ The output of the hand-tracking application can be visualized by means of the [i
 
 # 🎛 Dependencies
 visual-tracking-control suite depends on
- - [BayesFilters](https://github.com/robotology/bayes-filters-lib) - `version >= 0.6`
+ - [BayesFilters](https://github.com/robotology/bayes-filters-lib) - `version >= 0.9`
  - [iCub](https://github.com/robotology/icub-main)
  - [iCubContrib](https://github.com/robotology/icub-contrib-common)
  - [OpenCV](http://opencv.org) - `version >= 3.3`, built with `CUDA >= 8.0`

--- a/src/hand-tracking/CMakeLists.txt
+++ b/src/hand-tracking/CMakeLists.txt
@@ -153,6 +153,7 @@ set(${EXE_TARGET_NAME}_HDR
         include/VisualSIS.h
 		include/WalkmanArmModel.h
 		include/WalkmanCamera.h
+        include/utils.h
 )
 
 set(${EXE_TARGET_NAME}_SRC
@@ -174,6 +175,7 @@ set(${EXE_TARGET_NAME}_SRC
         src/VisualSIS.cpp
 		src/WalkmanArmModel.cpp
 		src/WalkmanCamera.cpp
+        src/utils.cpp
 )
 
 set(${EXE_TARGET_NAME}_CPU_SRC

--- a/src/hand-tracking/CMakeLists.txt
+++ b/src/hand-tracking/CMakeLists.txt
@@ -138,6 +138,7 @@ set(${EXE_TARGET_NAME}_HDR
         include/iCubGatePose.h
         include/InitiCubArm.h
         include/InitPoseParticles.h
+        include/InitPoseParticlesAxisAngle.h
         include/InitWalkmanArm.h
         include/KLD.h
         include/MeshModel.h
@@ -168,6 +169,7 @@ set(${EXE_TARGET_NAME}_SRC
         src/iCubGatePose.cpp
         src/InitiCubArm.cpp
         src/InitPoseParticles.cpp
+        src/InitPoseParticlesAxisAngle.cpp
         src/InitWalkmanArm.cpp
         src/PlayiCubFwdKinModel.cpp
         src/PlayGatePose.cpp

--- a/src/hand-tracking/CMakeLists.txt
+++ b/src/hand-tracking/CMakeLists.txt
@@ -24,10 +24,10 @@ if(NOT EIGEN3_FOUND)
     find_package(Eigen3 REQUIRED)
 endif()
 
-find_package(BayesFilters 0.7.1.0 QUIET)
+find_package(BayesFilters 0.9.0 QUIET)
 if(NOT BayesFilters_FOUND)
     message(STATUS "Did not found required master release of BayesFilters. Looking for devel version.")
-    find_package(BayesFilters 0.7.101 REQUIRED)
+    find_package(BayesFilters 0.9.100 REQUIRED)
 endif()
 
 find_package(SuperimposeMesh 0.9.4.0 QUIET)

--- a/src/hand-tracking/CMakeLists.txt
+++ b/src/hand-tracking/CMakeLists.txt
@@ -127,7 +127,7 @@ endif()
 # Application source and header files
 set(${EXE_TARGET_NAME}_HDR
         include/BrownianMotionPose.h
-		include/Camera.h
+        include/Camera.h
         include/ChiSquare.h
         include/DrawParticlesImportanceThreshold.h
         include/KinPoseModel.h
@@ -153,8 +153,8 @@ set(${EXE_TARGET_NAME}_HDR
         include/PlayWalkmanPoseModel.h
         include/VisualProprioception.h
         include/VisualSIS.h
-		include/WalkmanArmModel.h
-		include/WalkmanCamera.h
+        include/WalkmanArmModel.h
+        include/WalkmanCamera.h
         include/utils.h
 )
 
@@ -177,8 +177,8 @@ set(${EXE_TARGET_NAME}_SRC
         src/PlayGatePose.cpp
         src/PlayWalkmanPoseModel.cpp
         src/VisualSIS.cpp
-		src/WalkmanArmModel.cpp
-		src/WalkmanCamera.cpp
+        src/WalkmanArmModel.cpp
+        src/WalkmanCamera.cpp
         src/utils.cpp
 )
 

--- a/src/hand-tracking/CMakeLists.txt
+++ b/src/hand-tracking/CMakeLists.txt
@@ -131,6 +131,7 @@ set(${EXE_TARGET_NAME}_HDR
         include/ChiSquare.h
         include/DrawParticlesImportanceThreshold.h
         include/KinPoseModel.h
+        include/KinPoseModelAxisAngle.h
         include/GatePose.h
         include/iCubFwdKinModel.h
         include/iCubArmModel.h
@@ -162,6 +163,7 @@ set(${EXE_TARGET_NAME}_SRC
         src/BrownianMotionPose.cpp
         src/DrawParticlesImportanceThreshold.cpp
         src/KinPoseModel.cpp
+        src/KinPoseModelAxisAngle.cpp
         src/GatePose.cpp
         src/iCubArmModel.cpp
         src/iCubCamera.cpp

--- a/src/hand-tracking/conf/config.ini
+++ b/src/hand-tracking/conf/config.ini
@@ -13,8 +13,9 @@ resolution_ratio 1.0
 q_x        0.001
 q_y        0.001
 q_z        0.001
-theta      0.1
-cone_angle 0.1
+q_yaw      0.001
+q_pitch    0.001
+q_roll     0.001
 seed       1.0
 
 [VISUALPROPRIOCEPTION]

--- a/src/hand-tracking/conf/config.ini
+++ b/src/hand-tracking/conf/config.ini
@@ -23,8 +23,8 @@ use_thumb   0.0
 use_forearm 0.0
 
 [LIKELIHOOD]
-likelihood_type norm_two_chi
-likelihood_gain 0.001
+likelihood_type norm_one
+likelihood_gain 0.01
 
 [GATEPOSE]
 gate_x        0.1

--- a/src/hand-tracking/conf/config.ini
+++ b/src/hand-tracking/conf/config.ini
@@ -10,7 +10,8 @@ gate_pose        0.0
 resolution_ratio 1.0
 
 [BROWNIANMOTION]
-q_xy       0.001
+q_x        0.001
+q_y        0.001
 q_z        0.001
 theta      0.1
 cone_angle 0.1

--- a/src/hand-tracking/include/BrownianMotionPose.h
+++ b/src/hand-tracking/include/BrownianMotionPose.h
@@ -30,7 +30,7 @@ public:
 
     void motion(const Eigen::Ref<const Eigen::MatrixXd>& cur_state, Eigen::Ref<Eigen::MatrixXd> mot_state) override;
 
-    Eigen::MatrixXd getNoiseSample(const int num) override;
+    Eigen::MatrixXd getNoiseSample(const int num);
 
     Eigen::MatrixXd getNoiseCovarianceMatrix() override { return Eigen::MatrixXd::Zero(1, 1); };
 

--- a/src/hand-tracking/include/BrownianMotionPose.h
+++ b/src/hand-tracking/include/BrownianMotionPose.h
@@ -26,13 +26,13 @@ public:
 
     BrownianMotionPose& operator=(BrownianMotionPose&& bm) noexcept;
 
-    void propagate(const Eigen::Ref<const Eigen::MatrixXf>& cur_state, Eigen::Ref<Eigen::MatrixXf> prop_state) override;
+    void propagate(const Eigen::Ref<const Eigen::MatrixXd>& cur_state, Eigen::Ref<Eigen::MatrixXd> prop_state) override;
 
-    void motion(const Eigen::Ref<const Eigen::MatrixXf>& cur_state, Eigen::Ref<Eigen::MatrixXf> mot_state) override;
+    void motion(const Eigen::Ref<const Eigen::MatrixXd>& cur_state, Eigen::Ref<Eigen::MatrixXd> mot_state) override;
 
-    Eigen::MatrixXf getNoiseSample(const int num) override;
+    Eigen::MatrixXd getNoiseSample(const int num) override;
 
-    Eigen::MatrixXf getNoiseCovarianceMatrix() override { return Eigen::MatrixXf::Zero(1, 1); };
+    Eigen::MatrixXd getNoiseCovarianceMatrix() override { return Eigen::MatrixXd::Zero(1, 1); };
 
     bool setProperty(const std::string& property) override { return false; };
 
@@ -54,7 +54,7 @@ protected:
     std::function<float()>                gaussian_random_theta_;
     std::function<float()>                gaussian_random_cone_;
 
-    void addAxisangleDisturbance(const Eigen::Ref<const Eigen::MatrixXf>& disturbance_vec, Eigen::Ref<Eigen::MatrixXf> current_vec);
+    void addAxisangleDisturbance(const Eigen::Ref<const Eigen::MatrixXd>& disturbance_vec, Eigen::Ref<Eigen::MatrixXd> current_vec);
 };
 
 #endif /* BROWNIANMOTIONPOSE_H */

--- a/src/hand-tracking/include/BrownianMotionPose.h
+++ b/src/hand-tracking/include/BrownianMotionPose.h
@@ -36,6 +36,8 @@ public:
 
     bool setProperty(const std::string& property) override { return false; };
 
+    std::pair<std::size_t, std::size_t> getOutputSize() const override;
+
 protected:
     double                                 q_xy_;        /* Noise standard deviation for z   3D position */
     double                                 q_z_;         /* Noise standard deviation for x-y 3D position */

--- a/src/hand-tracking/include/BrownianMotionPose.h
+++ b/src/hand-tracking/include/BrownianMotionPose.h
@@ -10,9 +10,9 @@
 class BrownianMotionPose : public bfl::StateModel
 {
 public:
-    BrownianMotionPose(const double q_xy, const double q_z, const double theta, const double cone_angle, const unsigned int seed) noexcept;
+    BrownianMotionPose(const double q_x, const double q_y, const double q_z, const double theta, const double cone_angle, const unsigned int seed) noexcept;
 
-    BrownianMotionPose(const double q_xy, const double q_z, const double theta, const double cone_angle) noexcept;
+    BrownianMotionPose(const double q_x, const double q_y, const double q_z, const double theta, const double cone_angle) noexcept;
 
     BrownianMotionPose() noexcept;
 
@@ -39,19 +39,22 @@ public:
     std::pair<std::size_t, std::size_t> getOutputSize() const override;
 
 protected:
-    double                                 q_xy_;        /* Noise standard deviation for z   3D position */
-    double                                 q_z_;         /* Noise standard deviation for x-y 3D position */
+    double                                 q_x_;         /* Noise standard deviation for x 3D position */
+    double                                 q_y_;         /* Noise standard deviation for y 3D position */
+    double                                 q_z_;         /* Noise standard deviation for z 3D position */
     double                                 theta_;       /* Noise standard deviation for axis-angle rotation */
     double                                 cone_angle_;  /* Noise standard deviation for axis-angle axis cone */
 
     Eigen::Vector4f                        cone_dir_;    /* Cone direction of rotation. Fixed, left here for future implementation. */
 
     std::mt19937_64                        generator_;
-    std::normal_distribution<double>       distribution_pos_xy_;
+    std::normal_distribution<double>       distribution_pos_x_;
+    std::normal_distribution<double>       distribution_pos_y_;
     std::normal_distribution<double>       distribution_pos_z_;
     std::normal_distribution<double>       distribution_theta_;
     std::uniform_real_distribution<double> distribution_cone_;
-    std::function<double()>                gaussian_random_pos_xy_;
+    std::function<double()>                gaussian_random_pos_x_;
+    std::function<double()>                gaussian_random_pos_y_;
     std::function<double()>                gaussian_random_pos_z_;
     std::function<double()>                gaussian_random_theta_;
     std::function<double()>                gaussian_random_cone_;

--- a/src/hand-tracking/include/BrownianMotionPose.h
+++ b/src/hand-tracking/include/BrownianMotionPose.h
@@ -10,9 +10,9 @@
 class BrownianMotionPose : public bfl::StateModel
 {
 public:
-    BrownianMotionPose(const float q_xy, const float q_z, const float theta, const float cone_angle, const unsigned int seed) noexcept;
+    BrownianMotionPose(const double q_xy, const double q_z, const double theta, const double cone_angle, const unsigned int seed) noexcept;
 
-    BrownianMotionPose(const float q_xy, const float q_z, const float theta, const float cone_angle) noexcept;
+    BrownianMotionPose(const double q_xy, const double q_z, const double theta, const double cone_angle) noexcept;
 
     BrownianMotionPose() noexcept;
 
@@ -37,22 +37,22 @@ public:
     bool setProperty(const std::string& property) override { return false; };
 
 protected:
-    float                                 q_xy_;        /* Noise standard deviation for z   3D position */
-    float                                 q_z_;         /* Noise standard deviation for x-y 3D position */
-    float                                 theta_;       /* Noise standard deviation for axis-angle rotation */
-    float                                 cone_angle_;  /* Noise standard deviation for axis-angle axis cone */
+    double                                 q_xy_;        /* Noise standard deviation for z   3D position */
+    double                                 q_z_;         /* Noise standard deviation for x-y 3D position */
+    double                                 theta_;       /* Noise standard deviation for axis-angle rotation */
+    double                                 cone_angle_;  /* Noise standard deviation for axis-angle axis cone */
 
     Eigen::Vector4f                       cone_dir_;    /* Cone direction of rotation. Fixed, left here for future implementation. */
 
     std::mt19937_64                       generator_;
-    std::normal_distribution<float>       distribution_pos_xy_;
-    std::normal_distribution<float>       distribution_pos_z_;
-    std::normal_distribution<float>       distribution_theta_;
-    std::uniform_real_distribution<float> distribution_cone_;
-    std::function<float()>                gaussian_random_pos_xy_;
-    std::function<float()>                gaussian_random_pos_z_;
-    std::function<float()>                gaussian_random_theta_;
-    std::function<float()>                gaussian_random_cone_;
+    std::normal_distribution<double>       distribution_pos_xy_;
+    std::normal_distribution<double>       distribution_pos_z_;
+    std::normal_distribution<double>       distribution_theta_;
+    std::uniform_real_distribution<double> distribution_cone_;
+    std::function<double()>                gaussian_random_pos_xy_;
+    std::function<double()>                gaussian_random_pos_z_;
+    std::function<double()>                gaussian_random_theta_;
+    std::function<double()>                gaussian_random_cone_;
 
     void addAxisangleDisturbance(const Eigen::Ref<const Eigen::MatrixXd>& disturbance_vec, Eigen::Ref<Eigen::MatrixXd> current_vec);
 };

--- a/src/hand-tracking/include/BrownianMotionPose.h
+++ b/src/hand-tracking/include/BrownianMotionPose.h
@@ -44,9 +44,9 @@ protected:
     double                                 theta_;       /* Noise standard deviation for axis-angle rotation */
     double                                 cone_angle_;  /* Noise standard deviation for axis-angle axis cone */
 
-    Eigen::Vector4f                       cone_dir_;    /* Cone direction of rotation. Fixed, left here for future implementation. */
+    Eigen::Vector4f                        cone_dir_;    /* Cone direction of rotation. Fixed, left here for future implementation. */
 
-    std::mt19937_64                       generator_;
+    std::mt19937_64                        generator_;
     std::normal_distribution<double>       distribution_pos_xy_;
     std::normal_distribution<double>       distribution_pos_z_;
     std::normal_distribution<double>       distribution_theta_;

--- a/src/hand-tracking/include/BrownianMotionPose.h
+++ b/src/hand-tracking/include/BrownianMotionPose.h
@@ -30,7 +30,7 @@ public:
 
     void motion(const Eigen::Ref<const Eigen::MatrixXd>& cur_state, Eigen::Ref<Eigen::MatrixXd> mot_state) override;
 
-    Eigen::MatrixXd getNoiseSample(const int num);
+    Eigen::MatrixXd getNoiseSample(const std::size_t num);
 
     Eigen::MatrixXd getNoiseCovarianceMatrix() override { return Eigen::MatrixXd::Zero(1, 1); };
 

--- a/src/hand-tracking/include/BrownianMotionPose.h
+++ b/src/hand-tracking/include/BrownianMotionPose.h
@@ -10,9 +10,9 @@
 class BrownianMotionPose : public bfl::StateModel
 {
 public:
-    BrownianMotionPose(const double q_x, const double q_y, const double q_z, const double theta, const double cone_angle, const unsigned int seed) noexcept;
+    BrownianMotionPose(const double q_x, const double q_y, const double q_z, const double q_yaw, const double q_pitch, const double q_roll, const unsigned int seed) noexcept;
 
-    BrownianMotionPose(const double q_x, const double q_y, const double q_z, const double theta, const double cone_angle) noexcept;
+    BrownianMotionPose(const double q_x, const double q_y, const double q_z, const double q_yaw, const double q_pitch, const double q_roll) noexcept;
 
     BrownianMotionPose() noexcept;
 
@@ -42,24 +42,23 @@ protected:
     double                                 q_x_;         /* Noise standard deviation for x 3D position */
     double                                 q_y_;         /* Noise standard deviation for y 3D position */
     double                                 q_z_;         /* Noise standard deviation for z 3D position */
-    double                                 theta_;       /* Noise standard deviation for axis-angle rotation */
-    double                                 cone_angle_;  /* Noise standard deviation for axis-angle axis cone */
-
-    Eigen::Vector4f                        cone_dir_;    /* Cone direction of rotation. Fixed, left here for future implementation. */
+    double                                 q_yaw_;       /* Noise standard deviation for yaw   Euler angle */
+    double                                 q_pitch_;     /* Noise standard deviation for pitch Euler angle */
+    double                                 q_roll_;      /* Noise standard deviation for roll  Euler angle */
 
     std::mt19937_64                        generator_;
     std::normal_distribution<double>       distribution_pos_x_;
     std::normal_distribution<double>       distribution_pos_y_;
     std::normal_distribution<double>       distribution_pos_z_;
-    std::normal_distribution<double>       distribution_theta_;
-    std::uniform_real_distribution<double> distribution_cone_;
+    std::normal_distribution<double>       distribution_yaw_;
+    std::normal_distribution<double>       distribution_pitch_;
+    std::normal_distribution<double>       distribution_roll_;
     std::function<double()>                gaussian_random_pos_x_;
     std::function<double()>                gaussian_random_pos_y_;
     std::function<double()>                gaussian_random_pos_z_;
-    std::function<double()>                gaussian_random_theta_;
-    std::function<double()>                gaussian_random_cone_;
-
-    void addAxisangleDisturbance(const Eigen::Ref<const Eigen::MatrixXd>& disturbance_vec, Eigen::Ref<Eigen::MatrixXd> current_vec);
+    std::function<double()>                gaussian_random_yaw_;
+    std::function<double()>                gaussian_random_pitch_;
+    std::function<double()>                gaussian_random_roll_;
 };
 
 #endif /* BROWNIANMOTIONPOSE_H */

--- a/src/hand-tracking/include/ChiSquare.h
+++ b/src/hand-tracking/include/ChiSquare.h
@@ -13,7 +13,7 @@ public:
 
     ~ChiSquare() noexcept;
 
-    std::pair<bool, Eigen::VectorXf> likelihood(const bfl::MeasurementModel& measurement_model, const Eigen::Ref<const Eigen::MatrixXf>& pred_states) override;
+    std::pair<bool, Eigen::VectorXd> likelihood(const bfl::MeasurementModel& measurement_model, const Eigen::Ref<const Eigen::MatrixXd>& pred_states) override;
 
 private:
     struct ImplData;

--- a/src/hand-tracking/include/DrawParticlesImportanceThreshold.h
+++ b/src/hand-tracking/include/DrawParticlesImportanceThreshold.h
@@ -1,6 +1,7 @@
 #ifndef DRAWPARTICLESIMPORTANCETHRESHOLD_H
 #define DRAWPARTICLESIMPORTANCETHRESHOLD_H
 
+#include <BayesFilters/ParticleSet.h>
 #include <BayesFilters/PFPrediction.h>
 #include <BayesFilters/StateModel.h>
 
@@ -32,8 +33,7 @@ public:
     void setExogenousModel(std::unique_ptr<ExogenousModel> exogenous_model) override;
 
 protected:
-    void predictStep(const Eigen::Ref<const Eigen::MatrixXf>& prev_states, const Eigen::Ref<const Eigen::VectorXf>& prev_weights,
-                     Eigen::Ref<Eigen::MatrixXf> pred_states, Eigen::Ref<Eigen::VectorXf> pred_weights) override;
+    void predictStep(const bfl::ParticleSet& prev_particles, bfl::ParticleSet& pred_particles) override;
 
     std::unique_ptr<StateModel> state_model_;
 

--- a/src/hand-tracking/include/GatePose.h
+++ b/src/hand-tracking/include/GatePose.h
@@ -1,6 +1,7 @@
 #ifndef GATEPOSE_H
 #define GATEPOSE_H
 
+#include <BayesFilters/ParticleSet.h>
 #include <BayesFilters/PFCorrectionDecorator.h>
 #include <BayesFilters/StateModel.h>
 
@@ -18,8 +19,7 @@ public:
     ~GatePose() noexcept;
 
 protected:
-    void correctStep(const Eigen::Ref<const Eigen::MatrixXf>& pred_states, const Eigen::Ref<const Eigen::VectorXf>& pred_weights,
-                     Eigen::Ref<Eigen::MatrixXf> cor_states, Eigen::Ref<Eigen::VectorXf> cor_weights) override;
+    void correctStep(const bfl::ParticleSet& pred_particles, bfl::ParticleSet& corr_particles) override;
 
     virtual Eigen::VectorXd readPose() = 0;
 

--- a/src/hand-tracking/include/GatePose.h
+++ b/src/hand-tracking/include/GatePose.h
@@ -23,11 +23,11 @@ protected:
 
     virtual Eigen::VectorXd readPose() = 0;
 
-    bool isInsideEllipsoid(const Eigen::Ref<const Eigen::VectorXf>& state);
+    bool isInsideEllipsoid(const Eigen::Ref<const Eigen::VectorXd>& state);
 
-    bool isWithinRotation(float rot_angle);
+    bool isWithinRotation(double rot_angle);
 
-    bool isInsideCone(const Eigen::Ref<const Eigen::VectorXf>& state);
+    bool isInsideCone(const Eigen::Ref<const Eigen::VectorXd>& state);
 
 private:
     double gate_x_;

--- a/src/hand-tracking/include/InitPoseParticles.h
+++ b/src/hand-tracking/include/InitPoseParticles.h
@@ -1,6 +1,7 @@
 #ifndef INITPOSEPARTICLES_H
 #define INITPOSEPARTICLES_H
 
+#include <BayesFilters/ParticleSet.h>
 #include <BayesFilters/ParticleSetInitialization.h>
 
 #include <iCub/iKin/iKinFwd.h>
@@ -14,7 +15,7 @@ class InitPoseParticles : public bfl::ParticleSetInitialization
 public:
     virtual ~InitPoseParticles() noexcept { };
 
-    bool initialize(Eigen::Ref<Eigen::MatrixXf> state, Eigen::Ref<Eigen::VectorXf> weight) override;
+    bool initialize(bfl::ParticleSet& particles) override;
 
 protected:
     virtual Eigen::VectorXd readPose() = 0;

--- a/src/hand-tracking/include/InitPoseParticlesAxisAngle.h
+++ b/src/hand-tracking/include/InitPoseParticlesAxisAngle.h
@@ -1,0 +1,19 @@
+#ifndef INITPOSEPARTICLESAXISANGLE_H
+#define INITPOSEPARTICLESAXISANGLE_H
+
+#include <InitPoseParticles.h>
+
+
+class InitPoseParticlesAxisAngle : public InitPoseParticles
+{
+public:
+    virtual ~InitPoseParticlesAxisAngle() noexcept;
+
+protected:
+    Eigen::VectorXd readPose() override;
+
+    virtual Eigen::VectorXd readPoseAxisAngle() = 0;
+};
+
+
+#endif /* INITPOSEPARTICLESAXISANGLE_H */

--- a/src/hand-tracking/include/InitWalkmanArm.h
+++ b/src/hand-tracking/include/InitWalkmanArm.h
@@ -1,7 +1,7 @@
 #ifndef INITWALKMANBARM_H
 #define INITWALKMANBARM_H
 
-#include <InitPoseParticles.h>
+#include <InitPoseParticlesAxisAngle.h>
 
 #include <yarp/os/Bottle.h>
 #include <yarp/os/BufferedPort.h>
@@ -10,7 +10,7 @@
 #include <string>
 
 
-class InitWalkmanArm : public InitPoseParticles
+class InitWalkmanArm : public InitPoseParticlesAxisAngle
 {
 public:
     InitWalkmanArm(const std::string& laterality, const std::string& port_prefix) noexcept;
@@ -20,7 +20,7 @@ public:
     ~InitWalkmanArm() noexcept;
 
 protected:
-    Eigen::VectorXd readPose() override;
+    Eigen::VectorXd readPoseAxisAngle() override;
 
 private:
     const std::string  log_ID_ = "[InitWalkmanArm]";

--- a/src/hand-tracking/include/InitWalkmanArm.h
+++ b/src/hand-tracking/include/InitWalkmanArm.h
@@ -13,10 +13,9 @@
 class InitWalkmanArm : public InitPoseParticles
 {
 public:
-    InitWalkmanArm(const std::string& cam_sel, const std::string& laterality,
-                   const std::string& port_prefix) noexcept;
+    InitWalkmanArm(const std::string& laterality, const std::string& port_prefix) noexcept;
 
-    InitWalkmanArm(const std::string& cam_sel, const std::string& laterality) noexcept;
+    InitWalkmanArm(const std::string& laterality) noexcept;
 
     ~InitWalkmanArm() noexcept;
 

--- a/src/hand-tracking/include/InitiCubArm.h
+++ b/src/hand-tracking/include/InitiCubArm.h
@@ -14,10 +14,9 @@
 class InitiCubArm : public InitPoseParticles
 {
 public:
-    InitiCubArm(const std::string& cam_sel, const std::string& laterality,
-                const std::string& port_prefix) noexcept;
+    InitiCubArm(const std::string& laterality, const std::string& port_prefix) noexcept;
 
-    InitiCubArm(const std::string& cam_sel, const std::string& laterality) noexcept;
+    InitiCubArm(const std::string& laterality) noexcept;
 
     ~InitiCubArm() noexcept;
 

--- a/src/hand-tracking/include/InitiCubArm.h
+++ b/src/hand-tracking/include/InitiCubArm.h
@@ -1,7 +1,7 @@
 #ifndef INITICUBARM_H
 #define INITICUBARM_H
 
-#include <InitPoseParticles.h>
+#include <InitPoseParticlesAxisAngle.h>
 
 #include <iCub/iKin/iKinFwd.h>
 #include <yarp/os/Bottle.h>
@@ -11,7 +11,7 @@
 #include <string>
 
 
-class InitiCubArm : public InitPoseParticles
+class InitiCubArm : public InitPoseParticlesAxisAngle
 {
 public:
     InitiCubArm(const std::string& laterality, const std::string& port_prefix) noexcept;
@@ -21,7 +21,7 @@ public:
     ~InitiCubArm() noexcept;
 
 protected:
-    Eigen::VectorXd readPose() override;
+    Eigen::VectorXd readPoseAxisAngle() override;
 
 private:
     const std::string  log_ID_ = "[InitiCubArm]";

--- a/src/hand-tracking/include/KLD.h
+++ b/src/hand-tracking/include/KLD.h
@@ -13,7 +13,7 @@ public:
 
     ~KLD() noexcept;
 
-    std::pair<bool, Eigen::VectorXf> likelihood(const bfl::MeasurementModel& measurement_model, const Eigen::Ref<const Eigen::MatrixXf>& pred_states) override;
+    std::pair<bool, Eigen::VectorXd> likelihood(const bfl::MeasurementModel& measurement_model, const Eigen::Ref<const Eigen::MatrixXd>& pred_states) override;
 
 private:
     struct ImplData;

--- a/src/hand-tracking/include/KinPoseModel.h
+++ b/src/hand-tracking/include/KinPoseModel.h
@@ -15,9 +15,9 @@ public:
 
     ~KinPoseModel() noexcept;
 
-    void propagate(const Eigen::Ref<const Eigen::MatrixXf>& cur_state, Eigen::Ref<Eigen::MatrixXf> prop_state) override;
+    void propagate(const Eigen::Ref<const Eigen::MatrixXd>& cur_state, Eigen::Ref<Eigen::MatrixXd> prop_state) override;
 
-    Eigen::MatrixXf getExogenousMatrix() override;
+    Eigen::MatrixXd getExogenousMatrix() override;
 
     bool setProperty(const std::string& property) override;
 

--- a/src/hand-tracking/include/KinPoseModel.h
+++ b/src/hand-tracking/include/KinPoseModel.h
@@ -30,12 +30,16 @@ protected:
 
     bool setDeltaMotion();
 
+    Eigen::Matrix3d relativeOrientation(const Eigen::Ref<const Eigen::VectorXd>& prev_pose, const Eigen::Ref<Eigen::VectorXd>& curr_pose);
+
+    Eigen::MatrixXd perturbOrientation(const Eigen::Ref<const Eigen::MatrixXd>& state, const Eigen::Ref<const Eigen::MatrixXd>& perturbation);
+
 private:
-    Eigen::VectorXd prev_ee_pose_    = Eigen::VectorXd::Zero(7);
+    Eigen::VectorXd prev_ee_pose_   = Eigen::VectorXd::Zero(6);
 
-    Eigen::VectorXd delta_hand_pose_ = Eigen::VectorXd::Zero(6);
+    Eigen::Vector3d delta_hand_pos_ = Eigen::Vector3d::Zero();
 
-    double          delta_angle_     = 0.0;
+    Eigen::Matrix3d delta_hand_rot_ = Eigen::Matrix3d::Zero();
 };
 
 #endif /* FWDPOSEMODEL_H */

--- a/src/hand-tracking/include/KinPoseModel.h
+++ b/src/hand-tracking/include/KinPoseModel.h
@@ -21,6 +21,8 @@ public:
 
     bool setProperty(const std::string& property) override;
 
+    std::pair<std::size_t, std::size_t> getOutputSize() const override;
+
 protected:
     virtual Eigen::VectorXd readPose() = 0;
 

--- a/src/hand-tracking/include/KinPoseModelAxisAngle.h
+++ b/src/hand-tracking/include/KinPoseModelAxisAngle.h
@@ -1,0 +1,19 @@
+#ifndef KINPOSEMODELAXISANGLE_H
+#define KINPOSEMODELAXISANGLE_H
+
+#include <KinPoseModel.h>
+
+#include <Eigen/Dense>
+
+class KinPoseModelAxisAngle : public KinPoseModel
+{
+public:
+    virtual ~KinPoseModelAxisAngle() noexcept;
+
+protected:
+    Eigen::VectorXd readPose() override;
+
+    virtual Eigen::VectorXd readPoseAxisAngle() = 0;
+};
+
+#endif /* KINPOSEMODELAXISANGLE_H */

--- a/src/hand-tracking/include/MeshModel.h
+++ b/src/hand-tracking/include/MeshModel.h
@@ -20,7 +20,7 @@ public:
 
     virtual std::tuple<bool, std::string> getShaderPaths() = 0;
 
-    virtual std::tuple<bool, std::vector<Superimpose::ModelPoseContainer>> getModelPose(const Eigen::Ref<const Eigen::MatrixXf>& cur_states) = 0;
+    virtual std::tuple<bool, std::vector<Superimpose::ModelPoseContainer>> getModelPose(const Eigen::Ref<const Eigen::MatrixXd>& cur_states) = 0;
 };
 
 #endif /* MESHMODEL_H */

--- a/src/hand-tracking/include/NormOne.h
+++ b/src/hand-tracking/include/NormOne.h
@@ -13,7 +13,7 @@ public:
 
     ~NormOne() noexcept;
 
-    std::pair<bool, Eigen::VectorXf> likelihood(const bfl::MeasurementModel& measurement_model, const Eigen::Ref<const Eigen::MatrixXf>& pred_states) override;
+    std::pair<bool, Eigen::VectorXd> likelihood(const bfl::MeasurementModel& measurement_model, const Eigen::Ref<const Eigen::MatrixXd>& pred_states) override;
 
 private:
     struct ImplData;

--- a/src/hand-tracking/include/NormTwo.h
+++ b/src/hand-tracking/include/NormTwo.h
@@ -13,7 +13,7 @@ public:
 
     ~NormTwo() noexcept;
 
-    std::pair<bool, Eigen::VectorXf> likelihood(const bfl::MeasurementModel& measurement_model, const Eigen::Ref<const Eigen::MatrixXf>& pred_states) override;
+    std::pair<bool, Eigen::VectorXd> likelihood(const bfl::MeasurementModel& measurement_model, const Eigen::Ref<const Eigen::MatrixXd>& pred_states) override;
 
 private:
     struct ImplData;

--- a/src/hand-tracking/include/NormTwoChiSquare.h
+++ b/src/hand-tracking/include/NormTwoChiSquare.h
@@ -13,7 +13,7 @@ public:
 
     ~NormTwoChiSquare() noexcept;
 
-    std::pair<bool, Eigen::VectorXf> likelihood(const bfl::MeasurementModel& measurement_model, const Eigen::Ref<const Eigen::MatrixXf>& pred_states) override;
+    std::pair<bool, Eigen::VectorXd> likelihood(const bfl::MeasurementModel& measurement_model, const Eigen::Ref<const Eigen::MatrixXd>& pred_states) override;
 
 private:
     struct ImplData;

--- a/src/hand-tracking/include/NormTwoKLD.h
+++ b/src/hand-tracking/include/NormTwoKLD.h
@@ -13,7 +13,7 @@ public:
 
     ~NormTwoKLD() noexcept;
 
-    std::pair<bool, Eigen::VectorXf> likelihood(const bfl::MeasurementModel& measurement_model, const Eigen::Ref<const Eigen::MatrixXf>& pred_states) override;
+    std::pair<bool, Eigen::VectorXd> likelihood(const bfl::MeasurementModel& measurement_model, const Eigen::Ref<const Eigen::MatrixXd>& pred_states) override;
 
 private:
     struct ImplData;

--- a/src/hand-tracking/include/NormTwoKLDChiSquare.h
+++ b/src/hand-tracking/include/NormTwoKLDChiSquare.h
@@ -13,7 +13,7 @@ public:
 
     ~NormTwoKLDChiSquare() noexcept;
 
-    std::pair<bool, Eigen::VectorXf> likelihood(const bfl::MeasurementModel& measurement_model, const Eigen::Ref<const Eigen::MatrixXf>& pred_states) override;
+    std::pair<bool, Eigen::VectorXd> likelihood(const bfl::MeasurementModel& measurement_model, const Eigen::Ref<const Eigen::MatrixXd>& pred_states) override;
 
 private:
     struct ImplData;

--- a/src/hand-tracking/include/PlayWalkmanPoseModel.h
+++ b/src/hand-tracking/include/PlayWalkmanPoseModel.h
@@ -1,7 +1,7 @@
 #ifndef PLAYWALKMANPOSEMODEL_H
 #define PLAYWALKMANPOSEMODEL_H
 
-#include <KinPoseModel.h>
+#include <KinPoseModelAxisAngle.h>
 
 #include <iCub/iKin/iKinFwd.h>
 #include <yarp/os/Bottle.h>
@@ -11,7 +11,7 @@
 #include <string>
 
 
-class PlayWalkmanPoseModel : public KinPoseModel
+class PlayWalkmanPoseModel : public KinPoseModelAxisAngle
 {
 public:
     PlayWalkmanPoseModel(const std::string& robot, const std::string& laterality, const std::string& port_prefix) noexcept;
@@ -21,7 +21,7 @@ public:
     bool setProperty(const std::string& property) override;
 
 protected:
-    Eigen::VectorXd readPose() override;
+    Eigen::VectorXd readPoseAxisAngle() override;
 
     yarp::sig::Vector readRootToEE();
 

--- a/src/hand-tracking/include/PlayiCubFwdKinModel.h
+++ b/src/hand-tracking/include/PlayiCubFwdKinModel.h
@@ -1,7 +1,7 @@
 #ifndef PLAYICUBFWDKINMODEL_H
 #define PLAYICUBFWDKINMODEL_H
 
-#include <KinPoseModel.h>
+#include <KinPoseModelAxisAngle.h>
 
 #include <iCub/iKin/iKinFwd.h>
 #include <yarp/os/Bottle.h>
@@ -11,7 +11,7 @@
 #include <string>
 
 
-class PlayiCubFwdKinModel : public KinPoseModel
+class PlayiCubFwdKinModel : public KinPoseModelAxisAngle
 {
 public:
     PlayiCubFwdKinModel(const std::string& robot, const std::string& laterality, const std::string& port_prefix) noexcept;
@@ -21,7 +21,7 @@ public:
     bool setProperty(const std::string& property) override;
 
 protected:
-    Eigen::VectorXd readPose() override;
+    Eigen::VectorXd readPoseAxisAngle() override;
 
     yarp::sig::Vector readTorso();
 

--- a/src/hand-tracking/include/VisualProprioception.h
+++ b/src/hand-tracking/include/VisualProprioception.h
@@ -22,15 +22,13 @@ public:
 
     virtual ~VisualProprioception() noexcept;
 
-    std::pair<bool, bfl::Data> measure(const Eigen::Ref<const Eigen::MatrixXf>& cur_states) const override;
+    std::pair<bool, bfl::Data> measure() const override;
 
-    std::pair<bool, bfl::Data> predictedMeasure(const Eigen::Ref<const Eigen::MatrixXf>& cur_states) const override;
+    std::pair<bool, bfl::Data> predictedMeasure(const Eigen::Ref<const Eigen::MatrixXd>& cur_states) const override;
 
     std::pair<bool, bfl::Data> innovation(const bfl::Data& predicted_measurements, const bfl::Data& measurements) const override;
 
-    bool bufferAgentData() const override;
-
-    std::pair<bool, bfl::Data> getAgentMeasurements() const override;
+    bool freezeMeasurements() override;
 
     /* IMPROVEME
      * Find a way to better communicate with the callee. Maybe a struct.

--- a/src/hand-tracking/include/VisualProprioception.h
+++ b/src/hand-tracking/include/VisualProprioception.h
@@ -42,6 +42,8 @@ public:
      */
     void superimpose(const Superimpose::ModelPoseContainer& obj2pos_map, cv::Mat& img);
 
+    std::pair<std::size_t, std::size_t> getOutputSize() const override;
+
 private:
     struct ImplData;
 

--- a/src/hand-tracking/include/VisualSIS.h
+++ b/src/hand-tracking/include/VisualSIS.h
@@ -84,6 +84,12 @@ protected:
 private:
     const std::string log_ID_ = "[VisualSIS]";
 
+    const std::size_t state_size_ = 6;
+
+    const std::size_t state_size_linear_ = 3;
+
+    const std::size_t state_size_circular_ = 3;
+
     std::string port_prefix_;
 
     bfl::ParticleSet pred_particle_;

--- a/src/hand-tracking/include/VisualSIS.h
+++ b/src/hand-tracking/include/VisualSIS.h
@@ -3,6 +3,11 @@
 
 #include <BayesFilters/EstimatesExtraction.h>
 #include <BayesFilters/ParticleFilter.h>
+#include <BayesFilters/ParticleSet.h>
+#include <BayesFilters/ParticleSetInitialization.h>
+#include <BayesFilters/PFPrediction.h>
+#include <BayesFilters/PFCorrection.h>
+#include <BayesFilters/Resampling.h>
 
 #include <chrono>
 #include <deque>
@@ -26,7 +31,11 @@ class VisualSIS: public bfl::ParticleFilter,
                  public VisualSISParticleFilterIDL
 {
 public:
-    VisualSIS(const std::string& cam_sel,
+    VisualSIS(std::unique_ptr<bfl::ParticleSetInitialization> initialization,
+              std::unique_ptr<bfl::PFPrediction> prediction,
+              std::unique_ptr<bfl::PFCorrection> correction,
+              std::unique_ptr<bfl::Resampling> resampling,
+              const std::string& cam_sel,
               const int num_particles,
               const double resample_ratio,
               const std::string& port_prefix);
@@ -77,13 +86,9 @@ private:
 
     std::string port_prefix_;
 
-    Eigen::MatrixXf pred_particle_;
+    bfl::ParticleSet pred_particle_;
 
-    Eigen::VectorXf pred_weight_;
-
-    Eigen::MatrixXf cor_particle_;
-
-    Eigen::VectorXf cor_weight_;
+    bfl::ParticleSet cor_particle_;
 
     bfl::EstimatesExtraction estimate_extraction_;
 

--- a/src/hand-tracking/include/WalkmanArmModel.h
+++ b/src/hand-tracking/include/WalkmanArmModel.h
@@ -23,7 +23,7 @@ public:
 
     std::tuple<bool, std::string> getShaderPaths();
 
-    std::tuple<bool, std::vector<Superimpose::ModelPoseContainer>> getModelPose(const Eigen::Ref<const Eigen::MatrixXf>& cur_states);
+    std::tuple<bool, std::vector<Superimpose::ModelPoseContainer>> getModelPose(const Eigen::Ref<const Eigen::MatrixXd>& cur_states);
 
 protected:
     bool file_found(const std::string& file);

--- a/src/hand-tracking/include/iCubArmModel.h
+++ b/src/hand-tracking/include/iCubArmModel.h
@@ -25,7 +25,7 @@ public:
 
     std::tuple<bool, std::string> getShaderPaths();
 
-    std::tuple<bool, std::vector<Superimpose::ModelPoseContainer>> getModelPose(const Eigen::Ref<const Eigen::MatrixXf>& cur_states);
+    std::tuple<bool, std::vector<Superimpose::ModelPoseContainer>> getModelPose(const Eigen::Ref<const Eigen::MatrixXd>& cur_states);
 
 protected:
     bool file_found(const std::string& file);

--- a/src/hand-tracking/include/iCubFwdKinModel.h
+++ b/src/hand-tracking/include/iCubFwdKinModel.h
@@ -1,7 +1,7 @@
 #ifndef ICUBFWDKINMODEL_H
 #define ICUBFWDKINMODEL_H
 
-#include <KinPoseModel.h>
+#include <KinPoseModelAxisAngle.h>
 
 #include <iCub/iKin/iKinFwd.h>
 #include <yarp/dev/PolyDriver.h>
@@ -11,7 +11,7 @@
 #include <string>
 
 
-class iCubFwdKinModel : public KinPoseModel
+class iCubFwdKinModel : public KinPoseModelAxisAngle
 {
 public:
     iCubFwdKinModel(const std::string& robot, const std::string& laterality, const std::string& port_prefix);
@@ -21,7 +21,7 @@ public:
     bool setProperty(const std::string& property) override;
 
 protected:
-    Eigen::VectorXd   readPose() override;
+    Eigen::VectorXd   readPoseAxisAngle() override;
 
     yarp::sig::Vector readTorso();
 

--- a/src/hand-tracking/include/utils.h
+++ b/src/hand-tracking/include/utils.h
@@ -20,6 +20,8 @@ std::size_t axis_of_rotation_to_index(const AxisOfRotation axis);
 Eigen::Vector3d axis_of_rotation_to_vector(const AxisOfRotation axis);
 
 Eigen::VectorXd axis_angle_to_euler(const Eigen::Ref<const Eigen::VectorXd>& axis, const double angle, const AxisOfRotation axis_1, const AxisOfRotation axis_2, const AxisOfRotation axis_3);
+
+Eigen::VectorXd euler_to_axis_angle(const Eigen::Ref<const Eigen::VectorXd>& euler_angles, const AxisOfRotation axis_1, const AxisOfRotation axis_2, const AxisOfRotation axis_3);
 }
 }
 #endif /* HANDTRACKINGUTILS_H */

--- a/src/hand-tracking/include/utils.h
+++ b/src/hand-tracking/include/utils.h
@@ -1,0 +1,25 @@
+#ifndef HANDTRACKINGUTILS_H
+#define HANDTRACKINGUTILS_H
+
+#include <Eigen/Dense>
+
+namespace hand_tracking
+{
+namespace utils
+{
+
+enum class AxisOfRotation
+{
+    UnitX,
+    UnitY,
+    UnitZ
+};
+
+std::size_t axis_of_rotation_to_index(const AxisOfRotation axis);
+
+Eigen::Vector3d axis_of_rotation_to_vector(const AxisOfRotation axis);
+
+Eigen::VectorXd axis_angle_to_euler(const Eigen::Ref<const Eigen::VectorXd>& axis, const double angle, const AxisOfRotation axis_1, const AxisOfRotation axis_2, const AxisOfRotation axis_3);
+}
+}
+#endif /* HANDTRACKINGUTILS_H */

--- a/src/hand-tracking/src/BrownianMotionPose.cpp
+++ b/src/hand-tracking/src/BrownianMotionPose.cpp
@@ -110,17 +110,17 @@ BrownianMotionPose& BrownianMotionPose::operator=(BrownianMotionPose&& brown) no
 }
 
 
-void BrownianMotionPose::propagate(const Eigen::Ref<const Eigen::MatrixXf>& cur_state, Eigen::Ref<Eigen::MatrixXf> prop_state)
+void BrownianMotionPose::propagate(const Eigen::Ref<const Eigen::MatrixXd>& cur_state, Eigen::Ref<Eigen::MatrixXd> prop_state)
 {
     prop_state = cur_state;
 }
 
 
-void BrownianMotionPose::motion(const Eigen::Ref<const Eigen::MatrixXf>& cur_state, Eigen::Ref<Eigen::MatrixXf> mot_state)
+void BrownianMotionPose::motion(const Eigen::Ref<const Eigen::MatrixXd>& cur_state, Eigen::Ref<Eigen::MatrixXd> mot_state)
 {
     propagate(cur_state, mot_state);
 
-    MatrixXf sample(7, mot_state.cols());
+    MatrixXd sample(7, mot_state.cols());
     sample = getNoiseSample(mot_state.cols());
 
     mot_state.topRows<3>() += sample.topRows<3>();
@@ -128,9 +128,9 @@ void BrownianMotionPose::motion(const Eigen::Ref<const Eigen::MatrixXf>& cur_sta
 }
 
 
-Eigen::MatrixXf BrownianMotionPose::getNoiseSample(const int num)
+Eigen::MatrixXd BrownianMotionPose::getNoiseSample(const int num)
 {
-    MatrixXf sample(7, num);
+    MatrixXd sample(7, num);
 
     /* Position */
     for (unsigned int i = 0; i < num; ++i)
@@ -160,7 +160,7 @@ Eigen::MatrixXf BrownianMotionPose::getNoiseSample(const int num)
 }
 
 
-void BrownianMotionPose::addAxisangleDisturbance(const Ref<const MatrixXf>& disturbance_vec, Ref<MatrixXf> current_vec)
+void BrownianMotionPose::addAxisangleDisturbance(const Ref<const MatrixXd>& disturbance_vec, Ref<MatrixXd> current_vec)
 {
     for (unsigned int i = 0; i < current_vec.cols(); ++i)
     {
@@ -171,21 +171,21 @@ void BrownianMotionPose::addAxisangleDisturbance(const Ref<const MatrixXf>& dist
 
 
         /* Find the rotation axis 'u' and rotation angle 'rot' [1] */
-        Vector3f def_dir(0.0, 0.0, 1.0);
+        Vector3d def_dir(0.0, 0.0, 1.0);
 
-        Vector3f u = def_dir.cross(current_vec.col(i).head<3>()).normalized();
+        Vector3d u = def_dir.cross(current_vec.col(i).head<3>()).normalized();
 
         float rot  = static_cast<float>(std::acos(current_vec.col(i).head<3>().dot(def_dir)));
 
 
         /* Convert rotation axis and angle to 3x3 rotation matrix [2] */
         /* [2] https://en.wikipedia.org/wiki/Rotation_matrix#Rotation_matrix_from_axis_and_angle */
-        Matrix3f cross_matrix;
+        Matrix3d cross_matrix;
         cross_matrix <<     0,  -u(2),   u(1),
                          u(2),      0,  -u(0),
                         -u(1),   u(0),      0;
 
-        Matrix3f R = std::cos(rot) * Matrix3f::Identity() + std::sin(rot) * cross_matrix + (1 - std::cos(rot)) * (u * u.transpose());
+        Matrix3d R = std::cos(rot) * Matrix3d::Identity() + std::sin(rot) * cross_matrix + (1 - std::cos(rot)) * (u * u.transpose());
 
 
         current_vec.col(i).head<3>() = (R * disturbance_vec.col(i).head<3>()).normalized();

--- a/src/hand-tracking/src/BrownianMotionPose.cpp
+++ b/src/hand-tracking/src/BrownianMotionPose.cpp
@@ -4,81 +4,90 @@
 #include <iostream>
 #include <utility>
 
+#include <BayesFilters/directional_statistics.h>
+
+using namespace bfl;
 using namespace Eigen;
 
 
-BrownianMotionPose::BrownianMotionPose(const double q_x, const double q_y, const double q_z, const double theta, const double cone_angle, const unsigned int seed) noexcept :
+BrownianMotionPose::BrownianMotionPose(const double q_x, const double q_y, const double q_z, const double q_yaw, const double q_pitch, const double q_roll, const unsigned int seed) noexcept :
     q_x_(q_x),
     q_y_(q_y),
     q_z_(q_z),
-    theta_(theta * (M_PI/180.0)),
-    cone_angle_(cone_angle * (M_PI/180.0)),
-    cone_dir_(Vector4f(0.0, 0.0, 1.0, 0.0)),
+    q_yaw_(q_yaw),
+    q_pitch_(q_pitch),
+    q_roll_(q_roll),
     generator_(std::mt19937_64(seed)),
     distribution_pos_x_(std::normal_distribution<double>(0.0, q_x)),
     distribution_pos_y_(std::normal_distribution<double>(0.0, q_y)),
     distribution_pos_z_(std::normal_distribution<double>(0.0, q_z)),
-    distribution_theta_(std::normal_distribution<double>(0.0, theta_)),
-    distribution_cone_(std::uniform_real_distribution<double>(0.0, 1.0)),
+    distribution_yaw_(std::normal_distribution<double>(0.0, q_yaw_)),
+    distribution_pitch_(std::normal_distribution<double>(0.0, q_pitch_)),
+    distribution_roll_(std::normal_distribution<double>(0.0, q_roll_)),
     gaussian_random_pos_x_([&] { return (distribution_pos_x_)(generator_); }),
     gaussian_random_pos_y_([&] { return (distribution_pos_y_)(generator_); }),
     gaussian_random_pos_z_([&] { return (distribution_pos_z_)(generator_); }),
-    gaussian_random_theta_([&] { return (distribution_theta_)(generator_); }),
-    gaussian_random_cone_([&] { return (distribution_cone_)(generator_); }) { }
+    gaussian_random_yaw_([&] { return (distribution_yaw_)(generator_); }),
+    gaussian_random_pitch_([&] { return (distribution_pitch_)(generator_); }),
+    gaussian_random_roll_([&] { return (distribution_roll_)(generator_); }) { }
 
 
-BrownianMotionPose::BrownianMotionPose(const double q_x, const double q_y, const double q_z, const double theta, const double cone_angle) noexcept :
-    BrownianMotionPose(q_x, q_y, q_z, theta, cone_angle, 1) { }
+BrownianMotionPose::BrownianMotionPose(const double q_x, const double q_y, const double q_z, const double q_yaw, const double q_pitch, const double q_roll) noexcept :
+    BrownianMotionPose(q_x, q_y, q_z, q_yaw, q_pitch, q_roll, 1) { }
 
 
 BrownianMotionPose::BrownianMotionPose() noexcept :
-    BrownianMotionPose(0.005, 0.005, 0.005, 3.0, 2.5, 1) { }
+    BrownianMotionPose(0.005, 0.005, 0.005, 0.1, 0.1, 0.1, 1) { }
 
 
 BrownianMotionPose::BrownianMotionPose(const BrownianMotionPose& brown) :
     q_x_(brown.q_x_),
     q_y_(brown.q_y_),
     q_z_(brown.q_z_),
-    theta_(brown.theta_),
-    cone_angle_(brown.cone_angle_),
-    cone_dir_(brown.cone_dir_),
+    q_yaw_(brown.q_yaw_),
+    q_pitch_(brown.q_pitch_),
+    q_roll_(brown.q_roll_),
     generator_(brown.generator_),
     distribution_pos_x_(brown.distribution_pos_x_),
     distribution_pos_y_(brown.distribution_pos_y_),
     distribution_pos_z_(brown.distribution_pos_z_),
-    distribution_theta_(brown.distribution_theta_),
-    distribution_cone_(brown.distribution_cone_),
+    distribution_yaw_(brown.distribution_yaw_),
+    distribution_pitch_(brown.distribution_pitch_),
+    distribution_roll_(brown.distribution_roll_),
     gaussian_random_pos_x_(brown.gaussian_random_pos_x_),
     gaussian_random_pos_y_(brown.gaussian_random_pos_y_),
     gaussian_random_pos_z_(brown.gaussian_random_pos_z_),
-    gaussian_random_theta_(brown.gaussian_random_theta_),
-    gaussian_random_cone_(brown.gaussian_random_cone_) { }
-
+    gaussian_random_yaw_(brown.gaussian_random_yaw_),
+    gaussian_random_pitch_(brown.gaussian_random_pitch_),
+    gaussian_random_roll_(brown.gaussian_random_roll_) { }
 
 BrownianMotionPose::BrownianMotionPose(BrownianMotionPose&& brown) noexcept :
     q_x_(brown.q_x_),
     q_y_(brown.q_y_),
     q_z_(brown.q_z_),
-    theta_(brown.theta_),
-    cone_angle_(brown.cone_angle_),
-    cone_dir_(std::move(brown.cone_dir_)),
+    q_yaw_(brown.q_yaw_),
+    q_pitch_(brown.q_pitch_),
+    q_roll_(brown.q_roll_),
     generator_(std::move(brown.generator_)),
     distribution_pos_x_(std::move(brown.distribution_pos_x_)),
     distribution_pos_y_(std::move(brown.distribution_pos_y_)),
     distribution_pos_z_(std::move(brown.distribution_pos_z_)),
-    distribution_theta_(std::move(brown.distribution_theta_)),
-    distribution_cone_(std::move(brown.distribution_cone_)),
+    distribution_yaw_(std::move(brown.distribution_yaw_)),
+    distribution_pitch_(std::move(brown.distribution_pitch_)),
+    distribution_roll_(std::move(brown.distribution_roll_)),
     gaussian_random_pos_x_(std::move(brown.gaussian_random_pos_x_)),
     gaussian_random_pos_y_(std::move(brown.gaussian_random_pos_y_)),
     gaussian_random_pos_z_(std::move(brown.gaussian_random_pos_z_)),
-    gaussian_random_theta_(std::move(brown.gaussian_random_theta_)),
-    gaussian_random_cone_(std::move(brown.gaussian_random_cone_))
+    gaussian_random_yaw_(std::move(brown.gaussian_random_yaw_)),
+    gaussian_random_pitch_(std::move(brown.gaussian_random_pitch_)),
+    gaussian_random_roll_(std::move(brown.gaussian_random_roll_))
 {
     brown.q_x_        = 0.0;
     brown.q_y_        = 0.0;
     brown.q_z_        = 0.0;
-    brown.theta_      = 0.0;
-    brown.cone_angle_ = 0.0;
+    brown.q_yaw_      = 0.0;
+    brown.q_pitch_    = 0.0;
+    brown.q_roll_     = 0.0;
 }
 
 
@@ -99,27 +108,30 @@ BrownianMotionPose& BrownianMotionPose::operator=(BrownianMotionPose&& brown) no
     q_x_        = brown.q_x_;
     q_y_        = brown.q_y_;
     q_z_        = brown.q_z_;
-    theta_      = brown.theta_;
-    cone_angle_ = brown.cone_angle_;
-    cone_dir_   = std::move(brown.cone_dir_);
+    q_yaw_      = brown.q_yaw_;
+    q_pitch_    = brown.q_pitch_;
+    q_roll_     = brown.q_roll_;
 
     generator_              = std::move(brown.generator_);
     distribution_pos_x_     = std::move(brown.distribution_pos_x_);
     distribution_pos_y_     = std::move(brown.distribution_pos_y_);
     distribution_pos_z_     = std::move(brown.distribution_pos_z_);
-    distribution_theta_     = std::move(brown.distribution_theta_);
-    distribution_cone_      = std::move(brown.distribution_cone_);
+    distribution_yaw_       = std::move(brown.distribution_yaw_);
+    distribution_pitch_     = std::move(brown.distribution_pitch_);
+    distribution_roll_       = std::move(brown.distribution_roll_);
     gaussian_random_pos_x_  = std::move(brown.gaussian_random_pos_x_);
     gaussian_random_pos_y_  = std::move(brown.gaussian_random_pos_y_);
     gaussian_random_pos_z_  = std::move(brown.gaussian_random_pos_z_);
-    gaussian_random_theta_  = std::move(brown.gaussian_random_theta_);
-    gaussian_random_cone_   = std::move(brown.gaussian_random_cone_);
+    gaussian_random_yaw_  = std::move(brown.gaussian_random_yaw_);
+    gaussian_random_pitch_  = std::move(brown.gaussian_random_pitch_);
+    gaussian_random_roll_  = std::move(brown.gaussian_random_roll_);
 
     brown.q_x_        = 0.0;
     brown.q_y_        = 0.0;
     brown.q_z_        = 0.0;
-    brown.theta_      = 0.0;
-    brown.cone_angle_ = 0.0;
+    brown.q_yaw_      = 0.0;
+    brown.q_pitch_    = 0.0;
+    brown.q_roll_     = 0.0;
 
     return *this;
 }
@@ -135,40 +147,26 @@ void BrownianMotionPose::motion(const Eigen::Ref<const Eigen::MatrixXd>& cur_sta
 {
     propagate(cur_state, mot_state);
 
-    MatrixXd sample(7, mot_state.cols());
+    MatrixXd sample(6, mot_state.cols());
     sample = getNoiseSample(mot_state.cols());
 
     mot_state.topRows<3>() += sample.topRows<3>();
-    addAxisangleDisturbance(sample.bottomRows<4>(), mot_state.bottomRows<4>());
+    mot_state.bottomRows<3>() = directional_statistics::directional_add(mot_state.bottomRows<3>(), sample.bottomRows<3>());
 }
 
 
 Eigen::MatrixXd BrownianMotionPose::getNoiseSample(const int num)
 {
-    MatrixXd sample(7, num);
+    MatrixXd sample(6, num);
 
-    /* Position */
     for (unsigned int i = 0; i < num; ++i)
     {
         sample(0, i) = gaussian_random_pos_x_();
         sample(1, i) = gaussian_random_pos_y_();
         sample(2, i) = gaussian_random_pos_z_();
-    }
-
-    /* Axis-angle vector */
-    /* Generate points on the spherical cap around the north pole [1]. */
-    /* [1] http://math.stackexchange.com/a/205589/81266 */
-    for(unsigned int i = 0; i < num; ++i)
-    {
-        double z   = gaussian_random_cone_() * (1 - cos(cone_angle_)) + cos(cone_angle_);
-        double phi = gaussian_random_cone_() * (2.0 * M_PI);
-        double x   = sqrt(1 - (z * z)) * cos(phi);
-        double y   = sqrt(1 - (z * z)) * sin(phi);
-
-        sample(3, i) = x;
-        sample(4, i) = y;
-        sample(5, i) = z;
-        sample(6, i) = gaussian_random_theta_();
+        sample(3, i) = gaussian_random_yaw_();
+        sample(4, i) = gaussian_random_pitch_();
+        sample(5, i) = gaussian_random_roll_();
     }
 
     return sample;
@@ -177,39 +175,5 @@ Eigen::MatrixXd BrownianMotionPose::getNoiseSample(const int num)
 
 std::pair<std::size_t, std::size_t> BrownianMotionPose::getOutputSize() const
 {
-    return std::make_pair(7, 0);
-}
-
-
-void BrownianMotionPose::addAxisangleDisturbance(const Ref<const MatrixXd>& disturbance_vec, Ref<MatrixXd> current_vec)
-{
-    for (unsigned int i = 0; i < current_vec.cols(); ++i)
-    {
-        double ang = current_vec(3, i) + disturbance_vec(3, i);
-
-        if      (ang >   M_PI) ang -= 2.0 * M_PI;
-        else if (ang <= -M_PI) ang += 2.0 * M_PI;
-
-
-        /* Find the rotation axis 'u' and rotation angle 'rot' [1] */
-        Vector3d def_dir(0.0, 0.0, 1.0);
-
-        Vector3d u = def_dir.cross(current_vec.col(i).head<3>()).normalized();
-
-        double rot  = static_cast<double>(std::acos(current_vec.col(i).head<3>().dot(def_dir)));
-
-
-        /* Convert rotation axis and angle to 3x3 rotation matrix [2] */
-        /* [2] https://en.wikipedia.org/wiki/Rotation_matrix#Rotation_matrix_from_axis_and_angle */
-        Matrix3d cross_matrix;
-        cross_matrix <<     0,  -u(2),   u(1),
-                         u(2),      0,  -u(0),
-                        -u(1),   u(0),      0;
-
-        Matrix3d R = std::cos(rot) * Matrix3d::Identity() + std::sin(rot) * cross_matrix + (1 - std::cos(rot)) * (u * u.transpose());
-
-
-        current_vec.col(i).head<3>() = (R * disturbance_vec.col(i).head<3>()).normalized();
-        current_vec(3, i)            = ang;
-    }
+    return std::make_pair(3, 3);
 }

--- a/src/hand-tracking/src/BrownianMotionPose.cpp
+++ b/src/hand-tracking/src/BrownianMotionPose.cpp
@@ -160,6 +160,12 @@ Eigen::MatrixXd BrownianMotionPose::getNoiseSample(const int num)
 }
 
 
+std::pair<std::size_t, std::size_t> BrownianMotionPose::getOutputSize() const
+{
+    return std::make_pair(7, 0);
+}
+
+
 void BrownianMotionPose::addAxisangleDisturbance(const Ref<const MatrixXd>& disturbance_vec, Ref<MatrixXd> current_vec)
 {
     for (unsigned int i = 0; i < current_vec.cols(); ++i)

--- a/src/hand-tracking/src/BrownianMotionPose.cpp
+++ b/src/hand-tracking/src/BrownianMotionPose.cpp
@@ -7,24 +7,24 @@
 using namespace Eigen;
 
 
-BrownianMotionPose::BrownianMotionPose(const float q_xy, const float q_z, const float theta, const float cone_angle, const unsigned int seed) noexcept :
+BrownianMotionPose::BrownianMotionPose(const double q_xy, const double q_z, const double theta, const double cone_angle, const unsigned int seed) noexcept :
     q_xy_(q_xy),
     q_z_(q_z),
     theta_(theta * (M_PI/180.0)),
     cone_angle_(cone_angle * (M_PI/180.0)),
     cone_dir_(Vector4f(0.0, 0.0, 1.0, 0.0)),
     generator_(std::mt19937_64(seed)),
-    distribution_pos_xy_(std::normal_distribution<float>(0.0, q_xy)),
-    distribution_pos_z_(std::normal_distribution<float>(0.0, q_z)),
-    distribution_theta_(std::normal_distribution<float>(0.0, theta_)),
-    distribution_cone_(std::uniform_real_distribution<float>(0.0, 1.0)),
+    distribution_pos_xy_(std::normal_distribution<double>(0.0, q_xy)),
+    distribution_pos_z_(std::normal_distribution<double>(0.0, q_z)),
+    distribution_theta_(std::normal_distribution<double>(0.0, theta_)),
+    distribution_cone_(std::uniform_real_distribution<double>(0.0, 1.0)),
     gaussian_random_pos_xy_([&] { return (distribution_pos_xy_)(generator_); }),
     gaussian_random_pos_z_([&] { return (distribution_pos_z_)(generator_); }),
     gaussian_random_theta_([&] { return (distribution_theta_)(generator_); }),
     gaussian_random_cone_([&] { return (distribution_cone_)(generator_); }) { }
 
 
-BrownianMotionPose::BrownianMotionPose(const float q_xy, const float q_z, const float theta, const float cone_angle) noexcept :
+BrownianMotionPose::BrownianMotionPose(const double q_xy, const double q_z, const double theta, const double cone_angle) noexcept :
     BrownianMotionPose(q_xy, q_z, theta, cone_angle, 1) { }
 
 
@@ -145,10 +145,10 @@ Eigen::MatrixXd BrownianMotionPose::getNoiseSample(const int num)
     /* [1] http://math.stackexchange.com/a/205589/81266 */
     for(unsigned int i = 0; i < num; ++i)
     {
-        float z   = gaussian_random_cone_() * (1 - cos(cone_angle_)) + cos(cone_angle_);
-        float phi = gaussian_random_cone_() * (2.0 * M_PI);
-        float x   = sqrt(1 - (z * z)) * cos(phi);
-        float y   = sqrt(1 - (z * z)) * sin(phi);
+        double z   = gaussian_random_cone_() * (1 - cos(cone_angle_)) + cos(cone_angle_);
+        double phi = gaussian_random_cone_() * (2.0 * M_PI);
+        double x   = sqrt(1 - (z * z)) * cos(phi);
+        double y   = sqrt(1 - (z * z)) * sin(phi);
 
         sample(3, i) = x;
         sample(4, i) = y;
@@ -164,7 +164,7 @@ void BrownianMotionPose::addAxisangleDisturbance(const Ref<const MatrixXd>& dist
 {
     for (unsigned int i = 0; i < current_vec.cols(); ++i)
     {
-        float ang = current_vec(3, i) + disturbance_vec(3, i);
+        double ang = current_vec(3, i) + disturbance_vec(3, i);
 
         if      (ang >   M_PI) ang -= 2.0 * M_PI;
         else if (ang <= -M_PI) ang += 2.0 * M_PI;
@@ -175,7 +175,7 @@ void BrownianMotionPose::addAxisangleDisturbance(const Ref<const MatrixXd>& dist
 
         Vector3d u = def_dir.cross(current_vec.col(i).head<3>()).normalized();
 
-        float rot  = static_cast<float>(std::acos(current_vec.col(i).head<3>().dot(def_dir)));
+        double rot  = static_cast<double>(std::acos(current_vec.col(i).head<3>().dot(def_dir)));
 
 
         /* Convert rotation axis and angle to 3x3 rotation matrix [2] */

--- a/src/hand-tracking/src/BrownianMotionPose.cpp
+++ b/src/hand-tracking/src/BrownianMotionPose.cpp
@@ -7,64 +7,75 @@
 using namespace Eigen;
 
 
-BrownianMotionPose::BrownianMotionPose(const double q_xy, const double q_z, const double theta, const double cone_angle, const unsigned int seed) noexcept :
-    q_xy_(q_xy),
+BrownianMotionPose::BrownianMotionPose(const double q_x, const double q_y, const double q_z, const double theta, const double cone_angle, const unsigned int seed) noexcept :
+    q_x_(q_x),
+    q_y_(q_y),
     q_z_(q_z),
     theta_(theta * (M_PI/180.0)),
     cone_angle_(cone_angle * (M_PI/180.0)),
     cone_dir_(Vector4f(0.0, 0.0, 1.0, 0.0)),
     generator_(std::mt19937_64(seed)),
-    distribution_pos_xy_(std::normal_distribution<double>(0.0, q_xy)),
+    distribution_pos_x_(std::normal_distribution<double>(0.0, q_x)),
+    distribution_pos_y_(std::normal_distribution<double>(0.0, q_y)),
     distribution_pos_z_(std::normal_distribution<double>(0.0, q_z)),
     distribution_theta_(std::normal_distribution<double>(0.0, theta_)),
     distribution_cone_(std::uniform_real_distribution<double>(0.0, 1.0)),
-    gaussian_random_pos_xy_([&] { return (distribution_pos_xy_)(generator_); }),
+    gaussian_random_pos_x_([&] { return (distribution_pos_x_)(generator_); }),
+    gaussian_random_pos_y_([&] { return (distribution_pos_y_)(generator_); }),
     gaussian_random_pos_z_([&] { return (distribution_pos_z_)(generator_); }),
     gaussian_random_theta_([&] { return (distribution_theta_)(generator_); }),
     gaussian_random_cone_([&] { return (distribution_cone_)(generator_); }) { }
 
 
-BrownianMotionPose::BrownianMotionPose(const double q_xy, const double q_z, const double theta, const double cone_angle) noexcept :
-    BrownianMotionPose(q_xy, q_z, theta, cone_angle, 1) { }
+BrownianMotionPose::BrownianMotionPose(const double q_x, const double q_y, const double q_z, const double theta, const double cone_angle) noexcept :
+    BrownianMotionPose(q_x, q_y, q_z, theta, cone_angle, 1) { }
 
 
 BrownianMotionPose::BrownianMotionPose() noexcept :
-    BrownianMotionPose(0.005, 0.005, 3.0, 2.5, 1) { }
+    BrownianMotionPose(0.005, 0.005, 0.005, 3.0, 2.5, 1) { }
 
 
 BrownianMotionPose::BrownianMotionPose(const BrownianMotionPose& brown) :
-    q_xy_(brown.q_xy_),
+    q_x_(brown.q_x_),
+    q_y_(brown.q_y_),
     q_z_(brown.q_z_),
     theta_(brown.theta_),
     cone_angle_(brown.cone_angle_),
     cone_dir_(brown.cone_dir_),
     generator_(brown.generator_),
-    distribution_pos_xy_(brown.distribution_pos_xy_),
+    distribution_pos_x_(brown.distribution_pos_x_),
+    distribution_pos_y_(brown.distribution_pos_y_),
     distribution_pos_z_(brown.distribution_pos_z_),
     distribution_theta_(brown.distribution_theta_),
     distribution_cone_(brown.distribution_cone_),
-    gaussian_random_pos_xy_(brown.gaussian_random_pos_xy_),
+    gaussian_random_pos_x_(brown.gaussian_random_pos_x_),
+    gaussian_random_pos_y_(brown.gaussian_random_pos_y_),
     gaussian_random_pos_z_(brown.gaussian_random_pos_z_),
     gaussian_random_theta_(brown.gaussian_random_theta_),
     gaussian_random_cone_(brown.gaussian_random_cone_) { }
 
 
 BrownianMotionPose::BrownianMotionPose(BrownianMotionPose&& brown) noexcept :
-    q_xy_(brown.q_xy_),
+    q_x_(brown.q_x_),
+    q_y_(brown.q_y_),
+    q_z_(brown.q_z_),
     theta_(brown.theta_),
     cone_angle_(brown.cone_angle_),
     cone_dir_(std::move(brown.cone_dir_)),
     generator_(std::move(brown.generator_)),
-    distribution_pos_xy_(std::move(brown.distribution_pos_xy_)),
+    distribution_pos_x_(std::move(brown.distribution_pos_x_)),
+    distribution_pos_y_(std::move(brown.distribution_pos_y_)),
     distribution_pos_z_(std::move(brown.distribution_pos_z_)),
     distribution_theta_(std::move(brown.distribution_theta_)),
     distribution_cone_(std::move(brown.distribution_cone_)),
-    gaussian_random_pos_xy_(std::move(brown.gaussian_random_pos_xy_)),
+    gaussian_random_pos_x_(std::move(brown.gaussian_random_pos_x_)),
+    gaussian_random_pos_y_(std::move(brown.gaussian_random_pos_y_)),
     gaussian_random_pos_z_(std::move(brown.gaussian_random_pos_z_)),
     gaussian_random_theta_(std::move(brown.gaussian_random_theta_)),
     gaussian_random_cone_(std::move(brown.gaussian_random_cone_))
 {
-    brown.q_xy_       = 0.0;
+    brown.q_x_        = 0.0;
+    brown.q_y_        = 0.0;
     brown.q_z_        = 0.0;
     brown.theta_      = 0.0;
     brown.cone_angle_ = 0.0;
@@ -85,23 +96,27 @@ BrownianMotionPose& BrownianMotionPose::operator=(const BrownianMotionPose& brow
 
 BrownianMotionPose& BrownianMotionPose::operator=(BrownianMotionPose&& brown) noexcept
 {
-    q_xy_       = brown.q_xy_;
+    q_x_        = brown.q_x_;
+    q_y_        = brown.q_y_;
     q_z_        = brown.q_z_;
     theta_      = brown.theta_;
     cone_angle_ = brown.cone_angle_;
     cone_dir_   = std::move(brown.cone_dir_);
 
     generator_              = std::move(brown.generator_);
-    distribution_pos_xy_    = std::move(brown.distribution_pos_xy_);
+    distribution_pos_x_     = std::move(brown.distribution_pos_x_);
+    distribution_pos_y_     = std::move(brown.distribution_pos_y_);
     distribution_pos_z_     = std::move(brown.distribution_pos_z_);
     distribution_theta_     = std::move(brown.distribution_theta_);
     distribution_cone_      = std::move(brown.distribution_cone_);
-    gaussian_random_pos_xy_ = std::move(brown.gaussian_random_pos_xy_);
+    gaussian_random_pos_x_  = std::move(brown.gaussian_random_pos_x_);
+    gaussian_random_pos_y_  = std::move(brown.gaussian_random_pos_y_);
     gaussian_random_pos_z_  = std::move(brown.gaussian_random_pos_z_);
     gaussian_random_theta_  = std::move(brown.gaussian_random_theta_);
     gaussian_random_cone_   = std::move(brown.gaussian_random_cone_);
 
-    brown.q_xy_       = 0.0;
+    brown.q_x_        = 0.0;
+    brown.q_y_        = 0.0;
     brown.q_z_        = 0.0;
     brown.theta_      = 0.0;
     brown.cone_angle_ = 0.0;
@@ -135,8 +150,8 @@ Eigen::MatrixXd BrownianMotionPose::getNoiseSample(const int num)
     /* Position */
     for (unsigned int i = 0; i < num; ++i)
     {
-        sample(0, i) = gaussian_random_pos_xy_();
-        sample(1, i) = gaussian_random_pos_xy_();
+        sample(0, i) = gaussian_random_pos_x_();
+        sample(1, i) = gaussian_random_pos_y_();
         sample(2, i) = gaussian_random_pos_z_();
     }
 

--- a/src/hand-tracking/src/BrownianMotionPose.cpp
+++ b/src/hand-tracking/src/BrownianMotionPose.cpp
@@ -155,11 +155,11 @@ void BrownianMotionPose::motion(const Eigen::Ref<const Eigen::MatrixXd>& cur_sta
 }
 
 
-Eigen::MatrixXd BrownianMotionPose::getNoiseSample(const int num)
+Eigen::MatrixXd BrownianMotionPose::getNoiseSample(const std::size_t num)
 {
     MatrixXd sample(6, num);
 
-    for (unsigned int i = 0; i < num; ++i)
+    for (std::size_t i = 0; i < num; ++i)
     {
         sample(0, i) = gaussian_random_pos_x_();
         sample(1, i) = gaussian_random_pos_y_();

--- a/src/hand-tracking/src/DrawParticlesImportanceThreshold.cpp
+++ b/src/hand-tracking/src/DrawParticlesImportanceThreshold.cpp
@@ -53,7 +53,7 @@ void DrawParticlesImportanceThreshold::setExogenousModel(std::unique_ptr<Exogeno
 
 void DrawParticlesImportanceThreshold::predictStep(const ParticleSet& prev_particles, ParticleSet& pred_particles)
 {
-    VectorXd sorted_cor = prev_particles.weight();
+    VectorXd sorted_cor = prev_particles.weight().array().exp();
 
     std::sort(sorted_cor.data(), sorted_cor.data() + sorted_cor.size());
     double threshold = sorted_cor.tail(6)(0);
@@ -72,7 +72,7 @@ void DrawParticlesImportanceThreshold::predictStep(const ParticleSet& prev_parti
         else
             tmp_state = prev_particles.state(j);
 
-        if (!getSkipState() && prev_particles.weight(j) <= threshold)
+        if (!getSkipState() && std::exp(prev_particles.weight(j)) <= threshold)
             state_model_->motion(tmp_state, pred_particles.state(j));
         else
             pred_particles.state(j) = tmp_state;

--- a/src/hand-tracking/src/DrawParticlesImportanceThreshold.cpp
+++ b/src/hand-tracking/src/DrawParticlesImportanceThreshold.cpp
@@ -51,32 +51,32 @@ void DrawParticlesImportanceThreshold::setExogenousModel(std::unique_ptr<Exogeno
 }
 
 
-void DrawParticlesImportanceThreshold::predictStep(const Ref<const MatrixXf>& prev_states, const Ref<const VectorXf>& prev_weights,
-                                                   Ref<MatrixXf> pred_states, Ref<VectorXf> pred_weights)
+void DrawParticlesImportanceThreshold::predictStep(const ParticleSet& prev_particles, ParticleSet& pred_particles)
 {
-    VectorXf sorted_cor = prev_weights;
+    VectorXd sorted_cor = prev_particles.weight();
+
     std::sort(sorted_cor.data(), sorted_cor.data() + sorted_cor.size());
-    float threshold = sorted_cor.tail(6)(0);
+    double threshold = sorted_cor.tail(6)(0);
 
     /* FIXME
        There should be no set property method here.
        There is a coupling with the prediction and pose-related exogenous models. */
     exogenous_model_->setProperty("kin_pose_delta");
 
-    for (int j = 0; j < prev_weights.rows(); ++j)
+    for (int j = 0; j < prev_particles.weight().size(); ++j)
     {
-        VectorXf tmp_states = VectorXf::Zero(prev_states.rows());
+        VectorXd tmp_state = VectorXd::Zero(prev_particles.state().rows());
 
         if (!getSkipExogenous())
-            exogenous_model_->propagate(prev_states.col(j), tmp_states);
+            exogenous_model_->propagate(prev_particles.state(j), tmp_state);
         else
-            tmp_states = prev_states.col(j);
+            tmp_state = prev_particles.state(j);
 
-        if (!getSkipState() && prev_weights(j) <= threshold)
-            state_model_->motion(tmp_states, pred_states.col(j));
+        if (!getSkipState() && prev_particles.weight(j) <= threshold)
+            state_model_->motion(tmp_state, pred_particles.state(j));
         else
-            pred_states.col(j) = tmp_states;
+            pred_particles.state(j) = tmp_state;
     }
 
-    pred_weights = prev_weights;
+    pred_particles.weight() = prev_particles.weight();
 }

--- a/src/hand-tracking/src/GatePose.cpp
+++ b/src/hand-tracking/src/GatePose.cpp
@@ -42,7 +42,7 @@ void GatePose::correctStep(const ParticleSet& pred_particles, ParticleSet& corr_
 }
 
 
-bool GatePose::isInsideEllipsoid(const Ref<const VectorXf>& state)
+bool GatePose::isInsideEllipsoid(const Ref<const VectorXd>& state)
 {
     return ( (abs(state(0) - ee_pose_(0)) <= gate_x_) &&
              (abs(state(1) - ee_pose_(1)) <= gate_y_) &&
@@ -50,23 +50,21 @@ bool GatePose::isInsideEllipsoid(const Ref<const VectorXf>& state)
 }
 
 
-bool GatePose::isWithinRotation(float rot_angle)
+bool GatePose::isWithinRotation(double rot_angle)
 {
-    float ang_diff = abs(rot_angle - ee_pose_(6));
+    double ang_diff = abs(rot_angle - ee_pose_(6));
 
     return (ang_diff <= gate_rotation_);
 }
 
 
-bool GatePose::isInsideCone(const Ref<const VectorXf>& state)
+bool GatePose::isInsideCone(const Ref<const VectorXd>& state)
 {
     /* See: http://stackoverflow.com/questions/10768142/verify-if-point-is-inside-a-cone-in-3d-space#10772759 */
 
     double   half_aperture    =  gate_aperture_ / 2.0;
 
-    VectorXd test_direction   = -state.cast<double>();
-
     VectorXd fwdkin_direction = -ee_pose_.middleRows<3>(3);
 
-    return ( (test_direction.dot(fwdkin_direction) / test_direction.norm() / fwdkin_direction.norm()) >= cos(half_aperture) );
+    return ( (state.dot(fwdkin_direction) / state.norm() / fwdkin_direction.norm()) >= cos(half_aperture) );
 }

--- a/src/hand-tracking/src/GatePose.cpp
+++ b/src/hand-tracking/src/GatePose.cpp
@@ -26,20 +26,18 @@ GatePose::GatePose(std::unique_ptr<PFCorrection> visual_correction) noexcept :
 GatePose::~GatePose() noexcept { }
 
 
-void GatePose::correctStep(const Ref<const MatrixXf>& pred_states, const Ref<const VectorXf>& pred_weights,
-                           Ref<MatrixXf> cor_states, Ref<VectorXf> cor_weights)
+void GatePose::correctStep(const ParticleSet& pred_particles, ParticleSet& corr_particles)
 {
-    PFCorrectionDecorator::correctStep(pred_states, pred_weights,
-                                       cor_states, cor_weights);
+    PFCorrectionDecorator::correctStep(pred_particles, corr_particles);
 
     ee_pose_ = readPose();
 
-    for (int i = 0; i < cor_states.cols(); ++i)
+    for (int i = 0; i < corr_particles.state().cols(); ++i)
     {
-        if (!isInsideEllipsoid(cor_states.col(i).head<3>())        ||
-            !isInsideCone     (cor_states.col(i).middleRows<3>(3)) ||
-            !isWithinRotation (cor_states(6, i))                     )
-            cor_weights(i) = std::numeric_limits<float>::min();
+        if (!isInsideEllipsoid(corr_particles.state(i).topRows<3>())     ||
+            !isInsideCone     (corr_particles.state(i).middleRows<3>(3)) ||
+            !isWithinRotation (corr_particles.state(i, 6))                 )
+            corr_particles.weight(i) = std::numeric_limits<double>::min();
     }
 }
 

--- a/src/hand-tracking/src/GatePose.cpp
+++ b/src/hand-tracking/src/GatePose.cpp
@@ -37,7 +37,7 @@ void GatePose::correctStep(const ParticleSet& pred_particles, ParticleSet& corr_
         if (!isInsideEllipsoid(corr_particles.state(i).topRows<3>())     ||
             !isInsideCone     (corr_particles.state(i).middleRows<3>(3)) ||
             !isWithinRotation (corr_particles.state(i, 6))                 )
-            corr_particles.weight(i) = std::numeric_limits<double>::min();
+            corr_particles.weight(i) = std::log(std::numeric_limits<double>::min());
     }
 }
 

--- a/src/hand-tracking/src/InitPoseParticles.cpp
+++ b/src/hand-tracking/src/InitPoseParticles.cpp
@@ -13,7 +13,7 @@ bool InitPoseParticles::initialize(ParticleSet& particles)
     for (int i = 0; i < particles.state().cols(); ++i)
         particles.state(i) << pose;
 
-    particles.weight().fill(1.0 / particles.state().cols());
+    particles.weight().fill(-std::log(particles.state().cols()));
 
     return true;
 }

--- a/src/hand-tracking/src/InitPoseParticles.cpp
+++ b/src/hand-tracking/src/InitPoseParticles.cpp
@@ -2,17 +2,18 @@
 
 #include <iCub/ctrl/math.h>
 
+using namespace bfl;
 using namespace Eigen;
 
 
-bool InitPoseParticles::initialize(Eigen::Ref<Eigen::MatrixXf> state, Eigen::Ref<Eigen::VectorXf> weight)
+bool InitPoseParticles::initialize(ParticleSet& particles)
 {
     VectorXd pose = readPose();
 
-    for (int i = 0; i < state.cols(); ++i)
-        state.col(i) << pose.cast<float>();
+    for (int i = 0; i < particles.state().cols(); ++i)
+        particles.state(i) << pose;
 
-    weight.fill(1.0 / state.cols());
+    particles.weight().fill(1.0 / particles.state().cols());
 
     return true;
 }

--- a/src/hand-tracking/src/InitPoseParticlesAxisAngle.cpp
+++ b/src/hand-tracking/src/InitPoseParticlesAxisAngle.cpp
@@ -1,0 +1,19 @@
+#include <InitPoseParticlesAxisAngle.h>
+#include <utils.h>
+
+using namespace Eigen;
+using namespace hand_tracking::utils;
+
+InitPoseParticlesAxisAngle::~InitPoseParticlesAxisAngle()
+{ }
+
+Eigen::VectorXd InitPoseParticlesAxisAngle::readPose()
+{
+    VectorXd pose_axis_angle = readPoseAxisAngle();
+
+    VectorXd pose(6);
+    pose.head<3>() = pose_axis_angle.head<3>();
+    pose.tail<3>() = axis_angle_to_euler(pose_axis_angle.segment<3>(3), pose_axis_angle(6), AxisOfRotation::UnitZ, AxisOfRotation::UnitY, AxisOfRotation::UnitX);
+
+    return pose;
+}

--- a/src/hand-tracking/src/InitWalkmanArm.cpp
+++ b/src/hand-tracking/src/InitWalkmanArm.cpp
@@ -12,16 +12,15 @@ using namespace yarp::sig;
 using namespace yarp::os;
 
 
-InitWalkmanArm::InitWalkmanArm(const std::string& cam_sel, const std::string& laterality,
-                               const std::string& port_prefix) noexcept :
+InitWalkmanArm::InitWalkmanArm(const std::string& laterality, const std::string& port_prefix) noexcept :
     port_prefix_(port_prefix)
 {
     port_arm_pose_.open("/" + port_prefix_ + "/" + laterality + "_arm:i");
 }
 
 
-InitWalkmanArm::InitWalkmanArm(const std::string& cam_sel, const std::string& laterality) noexcept :
-    InitWalkmanArm("InitWalkmanArm", cam_sel, laterality) { }
+InitWalkmanArm::InitWalkmanArm(const std::string& laterality) noexcept :
+    InitWalkmanArm("InitWalkmanArm", laterality) { }
 
 
 InitWalkmanArm::~InitWalkmanArm() noexcept

--- a/src/hand-tracking/src/InitWalkmanArm.cpp
+++ b/src/hand-tracking/src/InitWalkmanArm.cpp
@@ -30,7 +30,7 @@ InitWalkmanArm::~InitWalkmanArm() noexcept
 }
 
 
-VectorXd InitWalkmanArm::readPose()
+VectorXd InitWalkmanArm::readPoseAxisAngle()
 {
     return toEigen(readRootToEE());
 }

--- a/src/hand-tracking/src/InitiCubArm.cpp
+++ b/src/hand-tracking/src/InitiCubArm.cpp
@@ -40,7 +40,7 @@ InitiCubArm::~InitiCubArm() noexcept
 }
 
 
-VectorXd InitiCubArm::readPose()
+VectorXd InitiCubArm::readPoseAxisAngle()
 {
     return toEigen(icub_kin_arm_.EndEffPose(readRootToEE() * CTRL_DEG2RAD));
 }

--- a/src/hand-tracking/src/InitiCubArm.cpp
+++ b/src/hand-tracking/src/InitiCubArm.cpp
@@ -12,8 +12,7 @@ using namespace yarp::sig;
 using namespace yarp::os;
 
 
-InitiCubArm::InitiCubArm(const std::string& cam_sel, const std::string& laterality,
-                         const std::string& port_prefix) noexcept :
+InitiCubArm::InitiCubArm(const std::string& laterality, const std::string& port_prefix) noexcept :
     port_prefix_(port_prefix),
     icub_kin_arm_(iCubArm(laterality + "_v2"))
 {
@@ -27,8 +26,8 @@ InitiCubArm::InitiCubArm(const std::string& cam_sel, const std::string& laterali
 }
 
 
-InitiCubArm::InitiCubArm(const std::string& cam_sel, const std::string& laterality) noexcept :
-    InitiCubArm("InitiCubArm", cam_sel, laterality) { }
+InitiCubArm::InitiCubArm(const std::string& laterality) noexcept :
+    InitiCubArm("InitiCubArm", laterality) { }
 
 
 InitiCubArm::~InitiCubArm() noexcept

--- a/src/hand-tracking/src/KinPoseModel.cpp
+++ b/src/hand-tracking/src/KinPoseModel.cpp
@@ -68,6 +68,12 @@ bool KinPoseModel::setProperty(const std::string& property)
 }
 
 
+std::pair<std::size_t, std::size_t> KinPoseModel::getOutputSize() const
+{
+    return std::make_pair(7, 0);
+}
+
+
 bool KinPoseModel::setDeltaMotion()
 {
     VectorXd ee_pose = readPose();

--- a/src/hand-tracking/src/KinPoseModel.cpp
+++ b/src/hand-tracking/src/KinPoseModel.cpp
@@ -25,14 +25,14 @@ KinPoseModel::KinPoseModel() noexcept { }
 KinPoseModel::~KinPoseModel() noexcept { }
 
 
-void KinPoseModel::propagate(const Ref<const MatrixXf>& cur_state, Ref<MatrixXf> prop_state)
+void KinPoseModel::propagate(const Ref<const MatrixXd>& cur_state, Ref<MatrixXd> prop_state)
 {
     prop_state.topRows<3>() = cur_state.topRows<3>().colwise() + delta_hand_pose_.head<3>().cast<float>();
 
     prop_state.middleRows<3>(3) = (cur_state.middleRows<3>(3).colwise() + delta_hand_pose_.middleRows<3>(3).cast<float>());
     prop_state.middleRows<3>(3).colwise().normalize();
 
-    RowVectorXf ang = cur_state.bottomRows<1>().array() + static_cast<float>(delta_angle_);
+    RowVectorXd ang = cur_state.bottomRows<1>().array() + static_cast<float>(delta_angle_);
 
     for (unsigned int i = 0; i < ang.cols(); ++i)
     {
@@ -44,12 +44,12 @@ void KinPoseModel::propagate(const Ref<const MatrixXf>& cur_state, Ref<MatrixXf>
 }
 
 
-MatrixXf KinPoseModel::getExogenousMatrix()
+MatrixXd KinPoseModel::getExogenousMatrix()
 {
     std::cerr << "ERROR::PFPREDICTION::SETEXOGENOUSMODEL\n";
     std::cerr << "ERROR:\n\tCall to unimplemented base class method." << std::endl;
 
-    return MatrixXf::Zero(1, 1);
+    return MatrixXd::Zero(1, 1);
 }
 
 

--- a/src/hand-tracking/src/KinPoseModel.cpp
+++ b/src/hand-tracking/src/KinPoseModel.cpp
@@ -111,7 +111,7 @@ MatrixXd KinPoseModel::perturbOrientation(const Ref<const MatrixXd>& state, cons
     /*
      * Evaluate rotation matrix due to current pose.
      */
-    for (std::size_t i = 0; i < state.cols(); i++)
+    for (int i = 0; i < state.cols(); i++)
     {
         Matrix3d state_rot = (AngleAxisd(state(0, i), Vector3d::UnitZ())
                             * AngleAxisd(state(1, i), Vector3d::UnitY())

--- a/src/hand-tracking/src/KinPoseModel.cpp
+++ b/src/hand-tracking/src/KinPoseModel.cpp
@@ -27,20 +27,8 @@ KinPoseModel::~KinPoseModel() noexcept { }
 
 void KinPoseModel::propagate(const Ref<const MatrixXd>& cur_state, Ref<MatrixXd> prop_state)
 {
-    prop_state.topRows<3>() = cur_state.topRows<3>().colwise() + delta_hand_pose_.head<3>();
-
-    prop_state.middleRows<3>(3) = cur_state.middleRows<3>(3).colwise() + delta_hand_pose_.middleRows<3>(3);
-    prop_state.middleRows<3>(3).colwise().normalize();
-
-    RowVectorXd ang = cur_state.bottomRows<1>().array() + delta_angle_;
-
-    for (unsigned int i = 0; i < ang.cols(); ++i)
-    {
-        if      (ang(i) >   M_PI) ang(i) -= 2.0 * M_PI;
-        else if (ang(i) <= -M_PI) ang(i) += 2.0 * M_PI;
-    }
-
-    prop_state.bottomRows<1>() = ang;
+    prop_state.topRows<3>() = cur_state.topRows<3>().colwise() + delta_hand_pos_;
+    prop_state.bottomRows<3>() = perturbOrientation(cur_state.bottomRows<3>(), delta_hand_rot_);
 }
 
 
@@ -70,7 +58,7 @@ bool KinPoseModel::setProperty(const std::string& property)
 
 std::pair<std::size_t, std::size_t> KinPoseModel::getOutputSize() const
 {
-    return std::make_pair(7, 0);
+    return std::make_pair(3, 3);
 }
 
 
@@ -80,22 +68,65 @@ bool KinPoseModel::setDeltaMotion()
 
     if (!initialize_delta_)
     {
-        delta_hand_pose_.head<3>() = ee_pose.head<3>() - prev_ee_pose_.head<3>();
+        delta_hand_pos_ = ee_pose.head<3>() - prev_ee_pose_.head<3>();
 
-        delta_hand_pose_.middleRows<3>(3) = ee_pose.middleRows<3>(3) - prev_ee_pose_.middleRows<3>(3);
-
-        delta_angle_ = ee_pose(6) - prev_ee_pose_(6);
-        if      (delta_angle_ >   M_PI) delta_angle_ -= 2.0 * M_PI;
-        else if (delta_angle_ <= -M_PI) delta_angle_ += 2.0 * M_PI;
+        delta_hand_rot_.noalias() = relativeOrientation(prev_ee_pose_, ee_pose);
     }
     else
     {
-        delta_hand_pose_  = VectorXd::Zero(6);
-        delta_angle_      = 0.0;
+        delta_hand_pos_  = VectorXd::Zero(3);
+        delta_hand_rot_   = Matrix3d::Identity();
         initialize_delta_ = false;
     }
 
     prev_ee_pose_ = ee_pose;
 
     return true;
+}
+
+
+Matrix3d KinPoseModel::relativeOrientation(const Ref<const VectorXd>& prev_pose, const Ref<VectorXd>& curr_pose)
+{
+    /*
+     * Evaluate rotation matrix due to previous pose.
+     */
+    Matrix3d prev_rot = (AngleAxisd(prev_pose(3), Vector3d::UnitZ())
+                       * AngleAxisd(prev_pose(4), Vector3d::UnitY())
+                       * AngleAxisd(prev_pose(5), Vector3d::UnitX())).toRotationMatrix();
+
+    // Evaluate rotation matrix due to previous pose
+    Matrix3d curr_rot = (AngleAxisd(curr_pose(3), Vector3d::UnitZ())
+                       * AngleAxisd(curr_pose(4), Vector3d::UnitY())
+                       * AngleAxisd(curr_pose(5), Vector3d::UnitX())).toRotationMatrix();
+
+    // Evaluate relative rotation R s.t. current_rot = previous_rot * R;
+    return prev_rot.transpose() * curr_rot;
+}
+
+
+MatrixXd KinPoseModel::perturbOrientation(const Ref<const MatrixXd>& state, const Ref<const MatrixXd>& perturbation)
+{
+    MatrixXd perturbed_orientations(3, state.cols());
+
+    /*
+     * Evaluate rotation matrix due to current pose.
+     */
+    for (std::size_t i = 0; i < state.cols(); i++)
+    {
+        Matrix3d state_rot = (AngleAxisd(state(0, i), Vector3d::UnitZ())
+                            * AngleAxisd(state(1, i), Vector3d::UnitY())
+                            * AngleAxisd(state(2, i), Vector3d::UnitX())).toRotationMatrix();
+
+        /*
+         * Perturb rotation using the evaluated relative rotation.
+         */
+        Matrix3d perturbed_rot = state_rot * perturbation;
+
+        /*
+         * Extract ZYX Euler angles.
+         */
+        perturbed_orientations.col(i) = perturbed_rot.eulerAngles(2, 1, 0);
+    }
+
+    return perturbed_orientations;
 }

--- a/src/hand-tracking/src/KinPoseModel.cpp
+++ b/src/hand-tracking/src/KinPoseModel.cpp
@@ -27,12 +27,12 @@ KinPoseModel::~KinPoseModel() noexcept { }
 
 void KinPoseModel::propagate(const Ref<const MatrixXd>& cur_state, Ref<MatrixXd> prop_state)
 {
-    prop_state.topRows<3>() = cur_state.topRows<3>().colwise() + delta_hand_pose_.head<3>().cast<float>();
+    prop_state.topRows<3>() = cur_state.topRows<3>().colwise() + delta_hand_pose_.head<3>();
 
-    prop_state.middleRows<3>(3) = (cur_state.middleRows<3>(3).colwise() + delta_hand_pose_.middleRows<3>(3).cast<float>());
+    prop_state.middleRows<3>(3) = cur_state.middleRows<3>(3).colwise() + delta_hand_pose_.middleRows<3>(3);
     prop_state.middleRows<3>(3).colwise().normalize();
 
-    RowVectorXd ang = cur_state.bottomRows<1>().array() + static_cast<float>(delta_angle_);
+    RowVectorXd ang = cur_state.bottomRows<1>().array() + delta_angle_;
 
     for (unsigned int i = 0; i < ang.cols(); ++i)
     {

--- a/src/hand-tracking/src/KinPoseModelAxisAngle.cpp
+++ b/src/hand-tracking/src/KinPoseModelAxisAngle.cpp
@@ -1,0 +1,20 @@
+#include <KinPoseModelAxisAngle.h>
+#include <utils.h>
+
+using namespace Eigen;
+using namespace hand_tracking::utils;
+
+KinPoseModelAxisAngle::~KinPoseModelAxisAngle() noexcept
+{ }
+
+
+VectorXd KinPoseModelAxisAngle::readPose()
+{
+    VectorXd pose_axis_angle = readPoseAxisAngle();
+
+    VectorXd pose(6);
+    pose.head<3>() = pose_axis_angle.head<3>();
+    pose.tail<3>() = axis_angle_to_euler(pose_axis_angle.segment<3>(3), pose_axis_angle(6), AxisOfRotation::UnitZ, AxisOfRotation::UnitY, AxisOfRotation::UnitX);
+
+    return pose;
+}

--- a/src/hand-tracking/src/PlayWalkmanPoseModel.cpp
+++ b/src/hand-tracking/src/PlayWalkmanPoseModel.cpp
@@ -44,7 +44,7 @@ bool PlayWalkmanPoseModel::setProperty(const std::string& property)
 }
 
 
-VectorXd PlayWalkmanPoseModel::readPose()
+VectorXd PlayWalkmanPoseModel::readPoseAxisAngle()
 {
     return toEigen(readRootToEE());
 }

--- a/src/hand-tracking/src/PlayiCubFwdKinModel.cpp
+++ b/src/hand-tracking/src/PlayiCubFwdKinModel.cpp
@@ -54,10 +54,9 @@ bool PlayiCubFwdKinModel::setProperty(const std::string& property)
 }
 
 
-VectorXd PlayiCubFwdKinModel::readPose()
+VectorXd PlayiCubFwdKinModel::readPoseAxisAngle()
 {
-    Vector ee_pose = icub_kin_arm_.EndEffPose(CTRL_DEG2RAD * readRootToEE());
-    return toEigen(ee_pose);
+    return toEigen(icub_kin_arm_.EndEffPose(CTRL_DEG2RAD * readRootToEE()));
 }
 
 

--- a/src/hand-tracking/src/VisualSIS.cpp
+++ b/src/hand-tracking/src/VisualSIS.cpp
@@ -1,4 +1,5 @@
 #include <VisualSIS.h>
+#include <utils.h>
 
 #include <exception>
 #include <utility>
@@ -24,6 +25,7 @@ using namespace yarp::os;
 using yarp::sig::Vector;
 //using yarp::sig::ImageOf;
 //using yarp::sig::PixelRgb;
+using namespace hand_tracking::utils;
 
 
 VisualSIS::VisualSIS(std::unique_ptr<bfl::ParticleSetInitialization> initialization,
@@ -156,11 +158,19 @@ void VisualSIS::filteringStep()
 
 
     /* PALM */
+
+    /*
+     * Convert from Euler ZYX to axis angle.
+     */
     if (valid_estimate)
     {
+        VectorXd out_particle_axis_angle(7);
+        out_particle_axis_angle.head<3>() = out_particle.head<3>();
+        out_particle_axis_angle.segment<4>(3) = euler_to_axis_angle(out_particle.tail<3>(), AxisOfRotation::UnitZ, AxisOfRotation::UnitY, AxisOfRotation::UnitX);
+
         Vector& estimates_out = port_estimates_out_.prepare();
-        estimates_out.resize(state_size_);
-        toEigen(estimates_out) = out_particle;
+        estimates_out.resize(7);
+        toEigen(estimates_out) = out_particle_axis_angle;
         port_estimates_out_.write();
     }
 

--- a/src/hand-tracking/src/VisualSIS.cpp
+++ b/src/hand-tracking/src/VisualSIS.cpp
@@ -9,6 +9,8 @@
 #include <yarp/math/Math.h>
 #include <yarp/os/LogStream.h>
 
+#include <BayesFilters/utils.h>
+
 //#include <SuperimposeMesh/SICAD.h>
 //#include <VisualProprioception.h>
 
@@ -24,13 +26,21 @@ using yarp::sig::Vector;
 //using yarp::sig::PixelRgb;
 
 
-VisualSIS::VisualSIS(const std::string& cam_sel,
+VisualSIS::VisualSIS(std::unique_ptr<bfl::ParticleSetInitialization> initialization,
+                     std::unique_ptr<bfl::PFPrediction> prediction,
+                     std::unique_ptr<bfl::PFCorrection> correction,
+                     std::unique_ptr<bfl::Resampling> resampling,
+                     const std::string& cam_sel,
                      const int num_particles,
                      const double resample_ratio,
                      const std::string& port_prefix) :
+    ParticleFilter(std::move(initialization), std::move(prediction), std::move(correction), std::move(resampling)),
     num_particles_(num_particles),
     resample_ratio_(resample_ratio),
-    port_prefix_(port_prefix)
+    port_prefix_(port_prefix),
+    pred_particle_(num_particles_, 7),
+    cor_particle_(num_particles_, 7),
+    estimate_extraction_(7)
 {
     port_estimates_out_.open("/" + port_prefix_ + "/estimates:o");
 
@@ -42,15 +52,9 @@ VisualSIS::VisualSIS(const std::string& cam_sel,
 
 bool VisualSIS::initialization()
 {
-    pred_particle_ = MatrixXf(7, num_particles_);
-    pred_weight_   = VectorXf(num_particles_, 1);
-
-    cor_particle_ = MatrixXf(7, num_particles_);
-    cor_weight_   = VectorXf(num_particles_, 1);
-
     estimate_extraction_.clear();
 
-    initialization_->initialize(pred_particle_, pred_weight_);
+    initialization_->initialize(pred_particle_);
 
     prediction_->getExogenousModel().setProperty("init");
 
@@ -70,37 +74,36 @@ void VisualSIS::filteringStep()
 {
     /* PREDICTION */
     if (getFilteringStep() != 0)
-        prediction_->predict(cor_particle_, cor_weight_,
-                             pred_particle_, pred_weight_);
+        prediction_->predict(cor_particle_, pred_particle_);
 
 
     /* CORRECTION */
-    correction_->correct(pred_particle_, pred_weight_,
-                         cor_particle_, cor_weight_);
-    cor_weight_ /= cor_weight_.sum();
+    correction_->correct(pred_particle_, cor_particle_);
+    /* Normalize weights using LogSumExp. */
+    cor_particle_.weight().array() -= bfl::utils::log_sum_exp(cor_particle_.weight());
 
 
     /* STATE ESTIMATE EXTRACTION FROM PARTICLE SET */
-    VectorXf out_particle = estimate_extraction_.extract(cor_particle_, cor_weight_);
+    VectorXd out_particle;
+    bool valid_estimate = false;
+    std::tie(valid_estimate, out_particle) = estimate_extraction_.extract(cor_particle_.state(), cor_particle_.weight());
+    if (!valid_estimate)
+        yInfo() << log_ID_ << "Cannot extract point estimate!";
 
 
     /* RESAMPLING */
     yInfo() << log_ID_ << "Step:" << getFilteringStep();
-    yInfo() << log_ID_ << "Neff:" << resampling_->neff(cor_weight_);
-    if (resampling_->neff(cor_weight_) < std::round(num_particles_ * resample_ratio_))
+    yInfo() << log_ID_ << "Neff:" << resampling_->neff(cor_particle_.weight());
+    if (resampling_->neff(cor_particle_.weight()) < std::round(num_particles_ * resample_ratio_))
     {
         yInfo() << log_ID_ << "Resampling!";
 
-        MatrixXf res_particle(7, num_particles_);
-        VectorXf res_weight(num_particles_, 1);
-        VectorXf res_parent(num_particles_, 1);
+        ParticleSet res_particle(num_particles_, 7);
+        VectorXi res_parent(num_particles_, 1);
 
-        resampling_->resample(cor_particle_, cor_weight_,
-                              res_particle, res_weight,
-                              res_parent);
+        resampling_->resample(cor_particle_, res_particle, res_parent);
 
         cor_particle_ = res_particle;
-        cor_weight_   = res_weight;
     }
 
 
@@ -153,11 +156,13 @@ void VisualSIS::filteringStep()
 
 
     /* PALM */
-    Vector& estimates_out = port_estimates_out_.prepare();
-    estimates_out.resize(7);
-    toEigen(estimates_out) = out_particle.cast<double>();
-    port_estimates_out_.write();
-
+    if (valid_estimate)
+    {
+        Vector& estimates_out = port_estimates_out_.prepare();
+        estimates_out.resize(7);
+        toEigen(estimates_out) = out_particle;
+        port_estimates_out_.write();
+    }
 
     /* STATE ESTIMATE OUTPUT */
 //    Superimpose::ModelPoseContainer hand_pose;
@@ -298,6 +303,11 @@ bool VisualSIS::set_estimates_extraction_method(const std::string& method)
         estimate_extraction_.setMethod(EstimatesExtraction::ExtractionMethod::emode);
 
         return true;
+    }
+    else if ((method == "map") || (method == "smap") || (method == "wmap") || (method == "emap"))
+    {
+        /* These extraction methods are not supported. */
+        return false;
     }
 
     return false;

--- a/src/hand-tracking/src/VisualSIS.cpp
+++ b/src/hand-tracking/src/VisualSIS.cpp
@@ -38,9 +38,9 @@ VisualSIS::VisualSIS(std::unique_ptr<bfl::ParticleSetInitialization> initializat
     num_particles_(num_particles),
     resample_ratio_(resample_ratio),
     port_prefix_(port_prefix),
-    pred_particle_(num_particles_, 7),
-    cor_particle_(num_particles_, 7),
-    estimate_extraction_(7)
+    pred_particle_(num_particles_, state_size_),
+    cor_particle_(num_particles_, state_size_),
+    estimate_extraction_(state_size_linear_, state_size_circular_)
 {
     port_estimates_out_.open("/" + port_prefix_ + "/estimates:o");
 
@@ -98,7 +98,7 @@ void VisualSIS::filteringStep()
     {
         yInfo() << log_ID_ << "Resampling!";
 
-        ParticleSet res_particle(num_particles_, 7);
+        ParticleSet res_particle(num_particles_, state_size_);
         VectorXi res_parent(num_particles_, 1);
 
         resampling_->resample(cor_particle_, res_particle, res_parent);
@@ -159,7 +159,7 @@ void VisualSIS::filteringStep()
     if (valid_estimate)
     {
         Vector& estimates_out = port_estimates_out_.prepare();
-        estimates_out.resize(7);
+        estimates_out.resize(state_size_);
         toEigen(estimates_out) = out_particle;
         port_estimates_out_.write();
     }

--- a/src/hand-tracking/src/WalkmanArmModel.cpp
+++ b/src/hand-tracking/src/WalkmanArmModel.cpp
@@ -57,7 +57,7 @@ std::tuple<bool, std::string> WalkmanArmModel::getShaderPaths()
 }
 
 
-std::tuple<bool, std::vector<Superimpose::ModelPoseContainer>> WalkmanArmModel::getModelPose(const Eigen::Ref<const Eigen::MatrixXf>& cur_states)
+std::tuple<bool, std::vector<Superimpose::ModelPoseContainer>> WalkmanArmModel::getModelPose(const Eigen::Ref<const Eigen::MatrixXd>& cur_states)
 {
     std::vector<Superimpose::ModelPoseContainer> model_poses(cur_states.cols());
 

--- a/src/hand-tracking/src/WalkmanArmModel.cpp
+++ b/src/hand-tracking/src/WalkmanArmModel.cpp
@@ -1,4 +1,5 @@
 #include <WalkmanArmModel.h>
+#include <utils.h>
 
 #include <array>
 
@@ -12,7 +13,7 @@ using namespace iCub::ctrl;
 using namespace yarp::math;
 using namespace yarp::os;
 using namespace yarp::sig;
-
+using namespace hand_tracking::utils;
 
 WalkmanArmModel::WalkmanArmModel(const std::string& laterality,
                                  const std::string& context,
@@ -74,10 +75,11 @@ std::tuple<bool, std::vector<Superimpose::ModelPoseContainer>> WalkmanArmModel::
         ee_t(2) = cur_states(2, i);
         ee_t(3) = 1.0;
 
-        ee_o(0) = cur_states(3, i);
-        ee_o(1) = cur_states(4, i);
-        ee_o(2) = cur_states(5, i);
-        ee_o(3) = cur_states(6, i);
+        /*
+         * SuperimposeMeshLib requires axis-angle representation,
+         * hence the Euler ZYX representation stored in cur_states is converted to axis-angle.
+         */
+        ee_o = Vector(4, euler_to_axis_angle(cur_states.col(i).tail<3>(), AxisOfRotation::UnitZ, AxisOfRotation::UnitY, AxisOfRotation::UnitX).data());
 
         pose.assign(ee_t.data(), ee_t.data() + 3);
         pose.insert(pose.end(), ee_o.data(), ee_o.data() + 4);

--- a/src/hand-tracking/src/WalkmanCamera.cpp
+++ b/src/hand-tracking/src/WalkmanCamera.cpp
@@ -1,6 +1,7 @@
 #include <WalkmanCamera.h>
 
 #include <opencv2/core/core_c.h>
+#include <yarp/cv/Cv.h>
 #include <yarp/math/Math.h>
 #include <yarp/os/LogStream.h>
 #include <yarp/os/Property.h>
@@ -81,7 +82,7 @@ bool WalkmanCamera::bufferData()
     if (tmp_imgin != YARP_NULLPTR)
     {
         init_img_in_ = true;
-        image_ = cv::cvarrToMat(tmp_imgin->getIplImage()).clone();
+        image_ = yarp::cv::toCvMat(*tmp_imgin).clone();
     }
 
     if (init_img_in_)

--- a/src/hand-tracking/src/cpu/ChiSquare.cpp
+++ b/src/hand-tracking/src/cpu/ChiSquare.cpp
@@ -33,14 +33,14 @@ ChiSquare::~ChiSquare() noexcept
 { }
 
 
-std::pair<bool, VectorXf> ChiSquare::likelihood(const MeasurementModel& measurement_model, const Ref<const MatrixXf>& pred_states)
+std::pair<bool, VectorXd> ChiSquare::likelihood(const MeasurementModel& measurement_model, const Ref<const MatrixXd>& pred_states)
 {
     bool valid_measurements;
     Data data_measurements;
     std::tie(valid_measurements, data_measurements) = measurement_model.getAgentMeasurements();
 
     if (!valid_measurements)
-        return std::make_pair(false, VectorXf::Zero(1));
+        return std::make_pair(false, VectorXd::Zero(1));
 
     MatrixXf& measurements = any::any_cast<MatrixXf&>(data_measurements);
 
@@ -62,10 +62,10 @@ std::pair<bool, VectorXf> ChiSquare::likelihood(const MeasurementModel& measurem
     }
 
     if (!valid_predicted_measurements)
-        return std::make_pair(false, VectorXf::Zero(1));
+        return std::make_pair(false, VectorXd::Zero(1));
 
 
-    VectorXf likelihood(pred_states.cols());
+    VectorXd likelihood(pred_states.cols());
 
     for (int i = 0; i < pred_states.cols(); ++i)
     {
@@ -90,9 +90,9 @@ std::pair<bool, VectorXf> ChiSquare::likelihood(const MeasurementModel& measurem
             }
         }
 
-        likelihood(i) = static_cast<float>(sum_chi);
+        likelihood(i) = sum_chi;
     }
-    likelihood = (-static_cast<float>(pImpl_->likelihood_gain_) * likelihood).array().exp();
+    likelihood = (-(pImpl_->likelihood_gain_) * likelihood).array().exp();
 
 
     return std::make_pair(true, std::move(likelihood));

--- a/src/hand-tracking/src/cpu/ChiSquare.cpp
+++ b/src/hand-tracking/src/cpu/ChiSquare.cpp
@@ -37,7 +37,7 @@ std::pair<bool, VectorXd> ChiSquare::likelihood(const MeasurementModel& measurem
 {
     bool valid_measurements;
     Data data_measurements;
-    std::tie(valid_measurements, data_measurements) = measurement_model.getAgentMeasurements();
+    std::tie(valid_measurements, data_measurements) = measurement_model.measure();
 
     if (!valid_measurements)
         return std::make_pair(false, VectorXd::Zero(1));

--- a/src/hand-tracking/src/cpu/KLD.cpp
+++ b/src/hand-tracking/src/cpu/KLD.cpp
@@ -33,7 +33,7 @@ KLD::~KLD() noexcept
 { }
 
 
-std::pair<bool, VectorXf> KLD::likelihood(const MeasurementModel& measurement_model, const Ref<const MatrixXf>& pred_states)
+std::pair<bool, VectorXd> KLD::likelihood(const MeasurementModel& measurement_model, const Ref<const MatrixXd>& pred_states)
 {
     throw std::runtime_error("[KLD][CPU] Unimplemented.");
 }

--- a/src/hand-tracking/src/cpu/NormOne.cpp
+++ b/src/hand-tracking/src/cpu/NormOne.cpp
@@ -28,14 +28,14 @@ NormOne::NormOne(const double likelihood_gain) noexcept :
 NormOne::~NormOne() = default;
 
 
-std::pair<bool, VectorXf> NormOne::likelihood(const MeasurementModel& measurement_model, const Ref<const MatrixXf>& pred_states)
+std::pair<bool, VectorXd> NormOne::likelihood(const MeasurementModel& measurement_model, const Ref<const MatrixXd>& pred_states)
 {
     bool valid_agent_measurements;
     Data data_agent_measurements;
     std::tie(valid_agent_measurements, data_agent_measurements) = measurement_model.getAgentMeasurements();
 
     if (!valid_agent_measurements)
-        return std::make_pair(false, VectorXf::Zero(1));
+        return std::make_pair(false, VectorXd::Zero(1));
 
     MatrixXf& measurements = any::any_cast<MatrixXf&>(data_agent_measurements);
 
@@ -57,10 +57,10 @@ std::pair<bool, VectorXf> NormOne::likelihood(const MeasurementModel& measuremen
     }
 
     if (!valid_predicted_measurements)
-        return std::make_pair(false, VectorXf::Zero(1));
+        return std::make_pair(false, VectorXd::Zero(1));
 
 
-    VectorXf likelihood(pred_states.cols());
+    VectorXd likelihood(pred_states.cols());
 
     for (int i = 0; i < pred_states.cols(); ++i)
     {
@@ -68,10 +68,10 @@ std::pair<bool, VectorXf> NormOne::likelihood(const MeasurementModel& measuremen
         for (int j = 0; j < measurements.cols(); ++j)
             sum_diff += std::abs(measurements(0, j) - predicted_measurements(i, j));
 
-        likelihood(i) = static_cast<float>(sum_diff);
+        likelihood(i) = sum_diff;
     }
 
-    likelihood = (-static_cast<float>(pImpl_->likelihood_gain_) * likelihood).array().exp();
+    likelihood = (-(pImpl_->likelihood_gain_) * likelihood).array().exp();
 
 
     return std::make_pair(true, std::move(likelihood));

--- a/src/hand-tracking/src/cpu/NormOne.cpp
+++ b/src/hand-tracking/src/cpu/NormOne.cpp
@@ -30,14 +30,14 @@ NormOne::~NormOne() = default;
 
 std::pair<bool, VectorXd> NormOne::likelihood(const MeasurementModel& measurement_model, const Ref<const MatrixXd>& pred_states)
 {
-    bool valid_agent_measurements;
-    Data data_agent_measurements;
-    std::tie(valid_agent_measurements, data_agent_measurements) = measurement_model.getAgentMeasurements();
+    bool valid_measurements;
+    Data data_measurements;
+    std::tie(valid_measurements, data_measurements) = measurement_model.measure();
 
-    if (!valid_agent_measurements)
+    if (!valid_measurements)
         return std::make_pair(false, VectorXd::Zero(1));
 
-    MatrixXf& measurements = any::any_cast<MatrixXf&>(data_agent_measurements);
+    MatrixXf& measurements = any::any_cast<MatrixXf&>(data_measurements);
 
 
     bool valid_predicted_measurements;

--- a/src/hand-tracking/src/cpu/NormTwo.cpp
+++ b/src/hand-tracking/src/cpu/NormTwo.cpp
@@ -37,7 +37,7 @@ std::pair<bool, VectorXd> NormTwo::likelihood(const MeasurementModel& measuremen
 {
     bool valid_measurements;
     Data data_measurements;
-    std::tie(valid_measurements, data_measurements) = measurement_model.getAgentMeasurements();
+    std::tie(valid_measurements, data_measurements) = measurement_model.measure();
 
     if (!valid_measurements)
         return std::make_pair(false, VectorXd::Zero(1));

--- a/src/hand-tracking/src/cpu/NormTwo.cpp
+++ b/src/hand-tracking/src/cpu/NormTwo.cpp
@@ -33,14 +33,14 @@ NormTwo::~NormTwo() noexcept
 { }
 
 
-std::pair<bool, VectorXf> NormTwo::likelihood(const MeasurementModel& measurement_model, const Ref<const MatrixXf>& pred_states)
+std::pair<bool, VectorXd> NormTwo::likelihood(const MeasurementModel& measurement_model, const Ref<const MatrixXd>& pred_states)
 {
     bool valid_measurements;
     Data data_measurements;
     std::tie(valid_measurements, data_measurements) = measurement_model.getAgentMeasurements();
 
     if (!valid_measurements)
-        return std::make_pair(false, VectorXf::Zero(1));
+        return std::make_pair(false, VectorXd::Zero(1));
 
     MatrixXf& measurements = any::any_cast<MatrixXf&>(data_measurements);
 
@@ -62,10 +62,10 @@ std::pair<bool, VectorXf> NormTwo::likelihood(const MeasurementModel& measuremen
     }
 
     if (!valid_predicted_measurements)
-        return std::make_pair(false, VectorXf::Zero(1));
+        return std::make_pair(false, VectorXd::Zero(1));
 
 
-    VectorXf likelihood(pred_states.cols());
+    VectorXd likelihood(pred_states.cols());
 
     for (int i = 0; i < pred_states.cols(); ++i)
     {
@@ -90,9 +90,9 @@ std::pair<bool, VectorXf> NormTwo::likelihood(const MeasurementModel& measuremen
             }
         }
 
-        likelihood(i) = static_cast<float>(sum_norm_two);
+        likelihood(i) = sum_norm_two;
     }
-    likelihood = (-static_cast<float>(pImpl_->likelihood_gain_) * likelihood).array().exp();
+    likelihood = (-(pImpl_->likelihood_gain_) * likelihood).array().exp();
 
 
     return std::make_pair(true, std::move(likelihood));

--- a/src/hand-tracking/src/cpu/NormTwoChiSquare.cpp
+++ b/src/hand-tracking/src/cpu/NormTwoChiSquare.cpp
@@ -37,7 +37,7 @@ std::pair<bool, VectorXd> NormTwoChiSquare::likelihood(const MeasurementModel& m
 {
     bool valid_measurements;
     Data data_measurements;
-    std::tie(valid_measurements, data_measurements) = measurement_model.getAgentMeasurements();
+    std::tie(valid_measurements, data_measurements) = measurement_model.measure();
 
     if (!valid_measurements)
         return std::make_pair(false, VectorXd::Zero(1));

--- a/src/hand-tracking/src/cpu/NormTwoChiSquare.cpp
+++ b/src/hand-tracking/src/cpu/NormTwoChiSquare.cpp
@@ -33,14 +33,14 @@ NormTwoChiSquare::~NormTwoChiSquare() noexcept
 { }
 
 
-std::pair<bool, VectorXf> NormTwoChiSquare::likelihood(const MeasurementModel& measurement_model, const Ref<const MatrixXf>& pred_states)
+std::pair<bool, VectorXd> NormTwoChiSquare::likelihood(const MeasurementModel& measurement_model, const Ref<const MatrixXd>& pred_states)
 {
     bool valid_measurements;
     Data data_measurements;
     std::tie(valid_measurements, data_measurements) = measurement_model.getAgentMeasurements();
 
     if (!valid_measurements)
-        return std::make_pair(false, VectorXf::Zero(1));
+        return std::make_pair(false, VectorXd::Zero(1));
 
     MatrixXf& measurements = any::any_cast<MatrixXf&>(data_measurements);
 
@@ -62,10 +62,10 @@ std::pair<bool, VectorXf> NormTwoChiSquare::likelihood(const MeasurementModel& m
     }
 
     if (!valid_predicted_measurements)
-        return std::make_pair(false, VectorXf::Zero(1));
+        return std::make_pair(false, VectorXd::Zero(1));
 
 
-    VectorXf likelihood(pred_states.cols());
+    VectorXd likelihood(pred_states.cols());
 
     for (int i = 0; i < pred_states.cols(); ++i)
     {
@@ -96,9 +96,9 @@ std::pair<bool, VectorXf> NormTwoChiSquare::likelihood(const MeasurementModel& m
             }
         }
 
-        likelihood(i) = static_cast<float>(sum_norm_two_chi);
+        likelihood(i) = sum_norm_two_chi;
     }
-    likelihood = (-static_cast<float>(pImpl_->likelihood_gain_) * likelihood).array().exp();
+    likelihood = (-(pImpl_->likelihood_gain_) * likelihood).array().exp();
 
 
     return std::make_pair(true, std::move(likelihood));

--- a/src/hand-tracking/src/cpu/NormTwoKLD.cpp
+++ b/src/hand-tracking/src/cpu/NormTwoKLD.cpp
@@ -33,7 +33,7 @@ NormTwoKLD::~NormTwoKLD() noexcept
 { }
 
 
-std::pair<bool, VectorXf> NormTwoKLD::likelihood(const MeasurementModel& measurement_model, const Ref<const MatrixXf>& pred_states)
+std::pair<bool, VectorXd> NormTwoKLD::likelihood(const MeasurementModel& measurement_model, const Ref<const MatrixXd>& pred_states)
 {
     throw std::runtime_error("[NormTwoKLD][CPU] Unimplemented.");
 }

--- a/src/hand-tracking/src/cpu/NormTwoKLDChiSquare.cpp
+++ b/src/hand-tracking/src/cpu/NormTwoKLDChiSquare.cpp
@@ -33,7 +33,7 @@ NormTwoKLDChiSquare::~NormTwoKLDChiSquare() noexcept
 { }
 
 
-std::pair<bool, VectorXf> NormTwoKLDChiSquare::likelihood(const MeasurementModel& measurement_model, const Ref<const MatrixXf>& pred_states)
+std::pair<bool, VectorXd> NormTwoKLDChiSquare::likelihood(const MeasurementModel& measurement_model, const Ref<const MatrixXd>& pred_states)
 {
     throw std::runtime_error("[NormTwoKLDChiSquare][CPU] Unimplemented.");
 }

--- a/src/hand-tracking/src/cpu/VisualProprioception.cpp
+++ b/src/hand-tracking/src/cpu/VisualProprioception.cpp
@@ -185,6 +185,14 @@ std::pair<bool, bfl::Data> VisualProprioception::getAgentMeasurements() const
 }
 
 
+std::pair<std::size_t, std::size_t> VisualProprioception::getOutputSize() const
+{
+    /* The output size is set to (0, 0) since the measurements are stored in a row major format,
+       hence not compatible with the required output format. */
+    return std::make_pair(0, 0);
+}
+
+
 int VisualProprioception::getNumberOfUsedParticles() const
 {
     ImplData& rImpl = *pImpl_;

--- a/src/hand-tracking/src/cuda/ChiSquare.cpp
+++ b/src/hand-tracking/src/cuda/ChiSquare.cpp
@@ -53,7 +53,7 @@ std::pair<bool, VectorXd> ChiSquare::likelihood(const MeasurementModel& measurem
 
     bool valid_measurements;
     Data data_measurements;
-    std::tie(valid_measurements, data_measurements) = measurement_model.getAgentMeasurements();
+    std::tie(valid_measurements, data_measurements) = measurement_model.measure();
 
     if (!valid_measurements)
         return std::make_pair(false, VectorXd::Zero(1));

--- a/src/hand-tracking/src/cuda/ChiSquare.cpp
+++ b/src/hand-tracking/src/cuda/ChiSquare.cpp
@@ -46,7 +46,7 @@ ChiSquare::~ChiSquare() noexcept
 }
 
 
-std::pair<bool, VectorXf> ChiSquare::likelihood(const MeasurementModel& measurement_model, const Ref<const MatrixXf>& pred_states)
+std::pair<bool, VectorXd> ChiSquare::likelihood(const MeasurementModel& measurement_model, const Ref<const MatrixXd>& pred_states)
 {
     ImplData& rImpl = *pImpl_;
 
@@ -56,7 +56,7 @@ std::pair<bool, VectorXf> ChiSquare::likelihood(const MeasurementModel& measurem
     std::tie(valid_measurements, data_measurements) = measurement_model.getAgentMeasurements();
 
     if (!valid_measurements)
-        return std::make_pair(false, VectorXf::Zero(1));
+        return std::make_pair(false, VectorXd::Zero(1));
 
     cv::cuda::GpuMat measurements = any::any_cast<cv::cuda::GpuMat>(data_measurements);
 
@@ -68,14 +68,14 @@ std::pair<bool, VectorXf> ChiSquare::likelihood(const MeasurementModel& measurem
     cv::cuda::GpuMat predicted_measurements = any::any_cast<cv::cuda::GpuMat>(data_predicted_measurements);
 
     if (!valid_predicted_measurements)
-        return std::make_pair(false, VectorXf::Zero(1));
+        return std::make_pair(false, VectorXd::Zero(1));
 
     thrust::host_vector<float> device_normtwo_kld = bfl::cuda::chisquare(rImpl.handle_,
                                                                          measurements, predicted_measurements,
                                                                          rImpl.vector_size_);
 
-    Map<VectorXf> likelihood(device_normtwo_kld.data(), device_normtwo_kld.size());
-    likelihood = (-static_cast<float>(rImpl.likelihood_gain_) * likelihood).array().exp();
+    Map<VectorXf> likelihood_float(device_normtwo_kld.data(), device_normtwo_kld.size());
+    VectorXd likelihood = (-rImpl.likelihood_gain_ * likelihood_float.cast<double>()).array().exp();
 
 
     return std::make_pair(true, std::move(likelihood));

--- a/src/hand-tracking/src/cuda/KLD.cpp
+++ b/src/hand-tracking/src/cuda/KLD.cpp
@@ -53,7 +53,7 @@ std::pair<bool, VectorXd> KLD::likelihood(const MeasurementModel& measurement_mo
 
     bool valid_measurements;
     Data data_measurements;
-    std::tie(valid_measurements, data_measurements) = measurement_model.getAgentMeasurements();
+    std::tie(valid_measurements, data_measurements) = measurement_model.measure();
 
     if (!valid_measurements)
         return std::make_pair(false, VectorXd::Zero(1));

--- a/src/hand-tracking/src/cuda/KLD.cpp
+++ b/src/hand-tracking/src/cuda/KLD.cpp
@@ -46,7 +46,7 @@ KLD::~KLD() noexcept
 }
 
 
-std::pair<bool, VectorXf> KLD::likelihood(const MeasurementModel& measurement_model, const Ref<const MatrixXf>& pred_states)
+std::pair<bool, VectorXd> KLD::likelihood(const MeasurementModel& measurement_model, const Ref<const MatrixXd>& pred_states)
 {
     ImplData& rImpl = *pImpl_;
 
@@ -56,7 +56,7 @@ std::pair<bool, VectorXf> KLD::likelihood(const MeasurementModel& measurement_mo
     std::tie(valid_measurements, data_measurements) = measurement_model.getAgentMeasurements();
 
     if (!valid_measurements)
-        return std::make_pair(false, VectorXf::Zero(1));
+        return std::make_pair(false, VectorXd::Zero(1));
 
     cv::cuda::GpuMat measurements = any::any_cast<cv::cuda::GpuMat>(data_measurements);
 
@@ -68,14 +68,14 @@ std::pair<bool, VectorXf> KLD::likelihood(const MeasurementModel& measurement_mo
     cv::cuda::GpuMat predicted_measurements = any::any_cast<cv::cuda::GpuMat>(data_predicted_measurements);
 
     if (!valid_predicted_measurements)
-        return std::make_pair(false, VectorXf::Zero(1));
+        return std::make_pair(false, VectorXd::Zero(1));
 
     thrust::host_vector<float> device_normtwo_kld = bfl::cuda::kld(rImpl.handle_,
                                                                    measurements, predicted_measurements,
                                                                    rImpl.vector_size_);
 
-    Map<VectorXf> likelihood(device_normtwo_kld.data(), device_normtwo_kld.size());
-    likelihood = (-static_cast<float>(rImpl.likelihood_gain_) * likelihood).array().exp();
+    Map<VectorXf> likelihood_float(device_normtwo_kld.data(), device_normtwo_kld.size());
+    VectorXd likelihood = (-rImpl.likelihood_gain_ * likelihood.cast<double>()).array().exp();
 
 
     return std::make_pair(true, std::move(likelihood));

--- a/src/hand-tracking/src/cuda/NormOne.cpp
+++ b/src/hand-tracking/src/cuda/NormOne.cpp
@@ -49,7 +49,7 @@ std::pair<bool, VectorXd> NormOne::likelihood(const MeasurementModel& measuremen
 
     bool valid_measurements;
     Data data_measurements;
-    std::tie(valid_measurements, data_measurements) = measurement_model.getAgentMeasurements();
+    std::tie(valid_measurements, data_measurements) = measurement_model.measure();
 
     if (!valid_measurements)
         return std::make_pair(false, VectorXd::Zero(1));

--- a/src/hand-tracking/src/cuda/NormTwo.cpp
+++ b/src/hand-tracking/src/cuda/NormTwo.cpp
@@ -53,7 +53,7 @@ std::pair<bool, VectorXd> NormTwo::likelihood(const MeasurementModel& measuremen
 
     bool valid_measurements;
     Data data_measurements;
-    std::tie(valid_measurements, data_measurements) = measurement_model.getAgentMeasurements();
+    std::tie(valid_measurements, data_measurements) = measurement_model.measure();
 
     if (!valid_measurements)
         return std::make_pair(false, VectorXd::Zero(1));

--- a/src/hand-tracking/src/cuda/NormTwo.cpp
+++ b/src/hand-tracking/src/cuda/NormTwo.cpp
@@ -46,7 +46,7 @@ NormTwo::~NormTwo() noexcept
 }
 
 
-std::pair<bool, VectorXf> NormTwo::likelihood(const MeasurementModel& measurement_model, const Ref<const MatrixXf>& pred_states)
+std::pair<bool, VectorXd> NormTwo::likelihood(const MeasurementModel& measurement_model, const Ref<const MatrixXd>& pred_states)
 {
     ImplData& rImpl = *pImpl_;
 
@@ -56,7 +56,7 @@ std::pair<bool, VectorXf> NormTwo::likelihood(const MeasurementModel& measuremen
     std::tie(valid_measurements, data_measurements) = measurement_model.getAgentMeasurements();
 
     if (!valid_measurements)
-        return std::make_pair(false, VectorXf::Zero(1));
+        return std::make_pair(false, VectorXd::Zero(1));
 
     cv::cuda::GpuMat measurements = any::any_cast<cv::cuda::GpuMat>(data_measurements);
 
@@ -68,14 +68,14 @@ std::pair<bool, VectorXf> NormTwo::likelihood(const MeasurementModel& measuremen
     cv::cuda::GpuMat predicted_measurements = any::any_cast<cv::cuda::GpuMat>(data_predicted_measurements);
 
     if (!valid_predicted_measurements)
-        return std::make_pair(false, VectorXf::Zero(1));
+        return std::make_pair(false, VectorXd::Zero(1));
 
     thrust::host_vector<float> device_normtwo_kld = bfl::cuda::normtwo(rImpl.handle_,
                                                                        measurements, predicted_measurements,
                                                                        rImpl.vector_size_);
 
-    Map<VectorXf> likelihood(device_normtwo_kld.data(), device_normtwo_kld.size());
-    likelihood = (-static_cast<float>(rImpl.likelihood_gain_) * likelihood).array().exp();
+    Map<VectorXf> likelihood_float(device_normtwo_kld.data(), device_normtwo_kld.size());
+    VectorXd likelihood = (-rImpl.likelihood_gain_ * likelihood_float.cast<double>()).array().exp();
 
 
     return std::make_pair(true, std::move(likelihood));

--- a/src/hand-tracking/src/cuda/NormTwoChiSquare.cpp
+++ b/src/hand-tracking/src/cuda/NormTwoChiSquare.cpp
@@ -53,7 +53,7 @@ std::pair<bool, VectorXd> NormTwoChiSquare::likelihood(const MeasurementModel& m
 
     bool valid_measurements;
     Data data_measurements;
-    std::tie(valid_measurements, data_measurements) = measurement_model.getAgentMeasurements();
+    std::tie(valid_measurements, data_measurements) = measurement_model.measure();
 
     if (!valid_measurements)
         return std::make_pair(false, VectorXd::Zero(1));

--- a/src/hand-tracking/src/cuda/NormTwoChiSquare.cpp
+++ b/src/hand-tracking/src/cuda/NormTwoChiSquare.cpp
@@ -46,7 +46,7 @@ NormTwoChiSquare::~NormTwoChiSquare() noexcept
 }
 
 
-std::pair<bool, VectorXf> NormTwoChiSquare::likelihood(const MeasurementModel& measurement_model, const Ref<const MatrixXf>& pred_states)
+std::pair<bool, VectorXd> NormTwoChiSquare::likelihood(const MeasurementModel& measurement_model, const Ref<const MatrixXd>& pred_states)
 {
     ImplData& rImpl = *pImpl_;
 
@@ -56,7 +56,7 @@ std::pair<bool, VectorXf> NormTwoChiSquare::likelihood(const MeasurementModel& m
     std::tie(valid_measurements, data_measurements) = measurement_model.getAgentMeasurements();
 
     if (!valid_measurements)
-        return std::make_pair(false, VectorXf::Zero(1));
+        return std::make_pair(false, VectorXd::Zero(1));
 
     cv::cuda::GpuMat measurements = any::any_cast<cv::cuda::GpuMat>(data_measurements);
 
@@ -68,14 +68,14 @@ std::pair<bool, VectorXf> NormTwoChiSquare::likelihood(const MeasurementModel& m
     cv::cuda::GpuMat predicted_measurements = any::any_cast<cv::cuda::GpuMat>(data_predicted_measurements);
 
     if (!valid_predicted_measurements)
-        return std::make_pair(false, VectorXf::Zero(1));
+        return std::make_pair(false, VectorXd::Zero(1));
 
     thrust::host_vector<float> device_normtwo_kld = bfl::cuda::normtwo_chisquare(rImpl.handle_,
                                                                                  measurements, predicted_measurements,
                                                                                  rImpl.vector_size_);
 
-    Map<VectorXf> likelihood(device_normtwo_kld.data(), device_normtwo_kld.size());
-    likelihood = (-static_cast<float>(rImpl.likelihood_gain_) * likelihood).array().exp();
+    Map<VectorXf> likelihood_float(device_normtwo_kld.data(), device_normtwo_kld.size());
+    VectorXd likelihood = (-rImpl.likelihood_gain_ * likelihood_float.cast<double>()).array().exp();
 
 
     return std::make_pair(true, std::move(likelihood));

--- a/src/hand-tracking/src/cuda/NormTwoKLD.cpp
+++ b/src/hand-tracking/src/cuda/NormTwoKLD.cpp
@@ -53,7 +53,7 @@ std::pair<bool, VectorXd> NormTwoKLD::likelihood(const MeasurementModel& measure
 
     bool valid_measurements;
     Data data_measurements;
-    std::tie(valid_measurements, data_measurements) = measurement_model.getAgentMeasurements();
+    std::tie(valid_measurements, data_measurements) = measurement_model.measure();
 
     if (!valid_measurements)
         return std::make_pair(false, VectorXd::Zero(1));

--- a/src/hand-tracking/src/cuda/NormTwoKLDChiSquare.cpp
+++ b/src/hand-tracking/src/cuda/NormTwoKLDChiSquare.cpp
@@ -53,7 +53,7 @@ std::pair<bool, VectorXd> NormTwoKLDChiSquare::likelihood(const MeasurementModel
 
     bool valid_measurements;
     Data data_measurements;
-    std::tie(valid_measurements, data_measurements) = measurement_model.getAgentMeasurements();
+    std::tie(valid_measurements, data_measurements) = measurement_model.measure();
 
     if (!valid_measurements)
         return std::make_pair(false, VectorXd::Zero(1));

--- a/src/hand-tracking/src/cuda/NormTwoKLDChiSquare.cpp
+++ b/src/hand-tracking/src/cuda/NormTwoKLDChiSquare.cpp
@@ -46,7 +46,7 @@ NormTwoKLDChiSquare::~NormTwoKLDChiSquare() noexcept
 }
 
 
-std::pair<bool, VectorXf> NormTwoKLDChiSquare::likelihood(const MeasurementModel& measurement_model, const Ref<const MatrixXf>& pred_states)
+std::pair<bool, VectorXd> NormTwoKLDChiSquare::likelihood(const MeasurementModel& measurement_model, const Ref<const MatrixXd>& pred_states)
 {
     ImplData& rImpl = *pImpl_;
 
@@ -56,7 +56,7 @@ std::pair<bool, VectorXf> NormTwoKLDChiSquare::likelihood(const MeasurementModel
     std::tie(valid_measurements, data_measurements) = measurement_model.getAgentMeasurements();
 
     if (!valid_measurements)
-        return std::make_pair(false, VectorXf::Zero(1));
+        return std::make_pair(false, VectorXd::Zero(1));
 
     cv::cuda::GpuMat measurements = any::any_cast<cv::cuda::GpuMat>(data_measurements);
 
@@ -68,7 +68,7 @@ std::pair<bool, VectorXf> NormTwoKLDChiSquare::likelihood(const MeasurementModel
     cv::cuda::GpuMat predicted_measurements = any::any_cast<cv::cuda::GpuMat&&>(std::move(data_predicted_measurements));
 
     if (!valid_predicted_measurements)
-        return std::make_pair(false, VectorXf::Zero(1));
+        return std::make_pair(false, VectorXd::Zero(1));
 
 
     thrust::host_vector<float> device_normtwo_kld = bfl::cuda::normtwo_kld_chisquare(rImpl.handle_,
@@ -76,8 +76,8 @@ std::pair<bool, VectorXf> NormTwoKLDChiSquare::likelihood(const MeasurementModel
                                                                                      rImpl.vector_size_,
                                                                                      true);
 
-    Map<VectorXf> likelihood(device_normtwo_kld.data(), device_normtwo_kld.size());
-    likelihood = (-static_cast<float>(rImpl.likelihood_gain_) * likelihood).array().exp();
+    Map<VectorXf> likelihood_float(device_normtwo_kld.data(), device_normtwo_kld.size());
+    MatrixXd likelihood = (-rImpl.likelihood_gain_ * likelihood_float.cast<double>()).array().exp();
 
 
     return std::make_pair(true, std::move(likelihood));

--- a/src/hand-tracking/src/cuda/VisualProprioception.cpp
+++ b/src/hand-tracking/src/cuda/VisualProprioception.cpp
@@ -226,6 +226,14 @@ std::pair<bool, bfl::Data> VisualProprioception::getAgentMeasurements() const
 }
 
 
+std::pair<std::size_t, std::size_t> VisualProprioception::getOutputSize() const
+{
+    /* The output size is set to (0, 0) since the measurements are stored in a row major format,
+       hence not compatible with the required output format. */
+    return std::make_pair(0, 0);
+}
+
+
 int VisualProprioception::getNumberOfUsedParticles() const
 {
     ImplData& rImpl = *pImpl_;

--- a/src/hand-tracking/src/iCubArmModel.cpp
+++ b/src/hand-tracking/src/iCubArmModel.cpp
@@ -1,4 +1,5 @@
 #include <iCubArmModel.h>
+#include <utils.h>
 
 #include <iCub/ctrl/math.h>
 #include <yarp/math/Math.h>
@@ -6,11 +7,14 @@
 #include <yarp/os/LogStream.h>
 #include <yarp/sig/Vector.h>
 
+#include <Eigen/Dense>
+
 using namespace iCub::ctrl;
 using namespace iCub::iKin;
 using namespace yarp::math;
 using namespace yarp::os;
 using namespace yarp::sig;
+using namespace hand_tracking::utils;
 
 
 iCubArmModel::iCubArmModel(const bool use_thumb,
@@ -208,10 +212,11 @@ std::tuple<bool, std::vector<Superimpose::ModelPoseContainer>> iCubArmModel::get
             ee_t(2) = cur_states(2, i);
             ee_t(3) = 1.0;
 
-            ee_o(0) = cur_states(3, i);
-            ee_o(1) = cur_states(4, i);
-            ee_o(2) = cur_states(5, i);
-            ee_o(3) = cur_states(6, i);
+            /* 
+             * SuperimposeMeshLib requires axis-angle representation,
+             * hence the Euler ZYX representation stored in cur_states is converted to axis-angle.
+             */
+            ee_o = Vector(4, euler_to_axis_angle(cur_states.col(i).tail<3>(), AxisOfRotation::UnitZ, AxisOfRotation::UnitY, AxisOfRotation::UnitX).data());
 
             pose.assign(ee_t.data(), ee_t.data() + 3);
             pose.insert(pose.end(), ee_o.data(), ee_o.data() + 4);

--- a/src/hand-tracking/src/iCubArmModel.cpp
+++ b/src/hand-tracking/src/iCubArmModel.cpp
@@ -173,7 +173,7 @@ std::tuple<bool, std::string> iCubArmModel::getShaderPaths()
 }
 
 
-std::tuple<bool, std::vector<Superimpose::ModelPoseContainer>> iCubArmModel::getModelPose(const Eigen::Ref<const Eigen::MatrixXf>& cur_states)
+std::tuple<bool, std::vector<Superimpose::ModelPoseContainer>> iCubArmModel::getModelPose(const Eigen::Ref<const Eigen::MatrixXd>& cur_states)
 {
     bool success = false;
     std::vector<Superimpose::ModelPoseContainer> model_poses(cur_states.cols());

--- a/src/hand-tracking/src/iCubCamera.cpp
+++ b/src/hand-tracking/src/iCubCamera.cpp
@@ -4,6 +4,7 @@
 
 #include <iCub/ctrl/math.h>
 #include <opencv2/core/core_c.h>
+#include <yarp/cv/Cv.h>
 #include <yarp/math/Math.h>
 #include <yarp/os/LogStream.h>
 #include <yarp/os/Property.h>
@@ -144,7 +145,7 @@ bool iCubCamera::bufferData()
     if (tmp_imgin != YARP_NULLPTR)
     {
         init_img_in_ = true;
-        image_ = cv::cvarrToMat(tmp_imgin->getIplImage()).clone();
+        image_ = yarp::cv::toCvMat(*tmp_imgin).clone();
     }
 
     if (init_img_in_)

--- a/src/hand-tracking/src/iCubFwdKinModel.cpp
+++ b/src/hand-tracking/src/iCubFwdKinModel.cpp
@@ -110,11 +110,9 @@ bool iCubFwdKinModel::setProperty(const std::string& property)
 }
 
 
-VectorXd iCubFwdKinModel::readPose()
+VectorXd iCubFwdKinModel::readPoseAxisAngle()
 {
-    Vector ee_pose = icub_kin_arm_.EndEffPose(CTRL_DEG2RAD * readRootToEE());
-
-    return toEigen(ee_pose);
+    return toEigen(icub_kin_arm_.EndEffPose(CTRL_DEG2RAD * readRootToEE()));
 }
 
 

--- a/src/hand-tracking/src/main.cpp
+++ b/src/hand-tracking/src/main.cpp
@@ -4,8 +4,9 @@
 #include <memory>
 #include <string>
 
+#include <BayesFilters/BootstrapCorrection.h>
 #include <BayesFilters/ResamplingWithPrior.h>
-#include <BayesFilters/UpdateParticles.h>
+
 #include <yarp/os/LogStream.h>
 #include <yarp/os/Network.h>
 #include <yarp/os/ResourceFinder.h>
@@ -297,7 +298,7 @@ int main(int argc, char *argv[])
     }
 
     /* CORRECTION */
-    std::unique_ptr<PFCorrection> vpf_update_particles(new UpdateParticles());
+    std::unique_ptr<PFCorrection> vpf_update_particles(new BootstrapCorrection());
     vpf_update_particles->setLikelihoodModel(std::move(likelihood));
     vpf_update_particles->setMeasurementModel(std::move(proprio));
 

--- a/src/hand-tracking/src/main.cpp
+++ b/src/hand-tracking/src/main.cpp
@@ -97,10 +97,9 @@ int main(int argc, char *argv[])
     paramsd["q_x"]        = bottle_brownianmotion_params.check("q_x",        Value(0.005)).asDouble();
     paramsd["q_y"]        = bottle_brownianmotion_params.check("q_y",        Value(0.005)).asDouble();
     paramsd["q_z"]        = bottle_brownianmotion_params.check("q_z",        Value(0.005)).asDouble();
-    paramsd["theta"]      = bottle_brownianmotion_params.check("theta",      Value(3.0)).asDouble();
-    paramsd["cone_angle"] = bottle_brownianmotion_params.check("cone_angle", Value(2.5)).asDouble();
-    paramsd["seed"]       = bottle_brownianmotion_params.check("seed",       Value(1.0)).asDouble();
-
+    paramsd["q_yaw"]      = bottle_brownianmotion_params.check("q_yaw",      Value(0.001)).asDouble();
+    paramsd["q_pitch"]    = bottle_brownianmotion_params.check("q_pitch",    Value(0.001)).asDouble();
+    paramsd["q_roll"]      = bottle_brownianmotion_params.check("q_roll",      Value(0.001)).asDouble();
 
     /* Get Visual Proprioception parameters */
     yarp::os::Bottle bottle_visualproprioception_params = rf.findGroup("VISUALPROPRIOCEPTION");
@@ -145,9 +144,9 @@ int main(int argc, char *argv[])
     yInfo() << log_ID << " - q_x:"        << paramsd["q_x"];
     yInfo() << log_ID << " - q_y:"        << paramsd["q_y"];
     yInfo() << log_ID << " - q_z:"        << paramsd["q_z"];
-    yInfo() << log_ID << " - theta:"      << paramsd["theta"];
-    yInfo() << log_ID << " - cone_angle:" << paramsd["cone_angle"];
-    yInfo() << log_ID << " - seed:"       << paramsd["seed"];
+    yInfo() << log_ID << " - q_yaw:"      << paramsd["q_yaw"];
+    yInfo() << log_ID << " - q_pitch:"    << paramsd["q_pitch"];
+    yInfo() << log_ID << " - q_roll:"      << paramsd["q_roll"];
 
     yInfo() << log_ID << "Sensor model parameters:";
     yInfo() << log_ID << " - use_thumb:"   << paramsd["use_thumb"];
@@ -188,7 +187,7 @@ int main(int argc, char *argv[])
 
 
     /* MOTION MODEL */
-    std::unique_ptr<StateModel> brown(new BrownianMotionPose(paramsd["q_x"], paramsd["q_y"], paramsd["q_z"], paramsd["theta"], paramsd["cone_angle"], paramsd["seed"]));
+    std::unique_ptr<StateModel> brown(new BrownianMotionPose(paramsd["q_x"], paramsd["q_y"], paramsd["q_z"], paramsd["q_yaw"], paramsd["q_pitch"], paramsd["q_roll"], paramsd["seed"]));
 
     std::unique_ptr<ExogenousModel> robot_motion;
     if (paramss["robot"] == "icub")

--- a/src/hand-tracking/src/main.cpp
+++ b/src/hand-tracking/src/main.cpp
@@ -179,11 +179,9 @@ int main(int argc, char *argv[])
     /* INITIALIZATION */
     std::unique_ptr<ParticleSetInitialization> init_arm;
     if (paramss["robot"] == "icub")
-        init_arm = std::unique_ptr<InitiCubArm>(new InitiCubArm(paramss["cam_sel"], paramss["laterality"],
-                                                "handTracking/InitiCubArm/" + paramss["cam_sel"]));
+        init_arm = std::unique_ptr<InitiCubArm>(new InitiCubArm(paramss["laterality"], "handTracking/InitiCubArm/" + paramss["cam_sel"]));
     else if (paramss["robot"] == "walkman")
-        init_arm = std::unique_ptr<InitWalkmanArm>(new InitWalkmanArm(paramss["cam_sel"], paramss["laterality"],
-                                                   "handTracking/InitWalkmanArm/" + paramss["cam_sel"]));
+        init_arm = std::unique_ptr<InitWalkmanArm>(new InitWalkmanArm(paramss["laterality"], "handTracking/InitWalkmanArm/" + paramss["cam_sel"]));
 
 
     /* MOTION MODEL */
@@ -336,11 +334,9 @@ int main(int argc, char *argv[])
         std::unique_ptr<ParticleSetInitialization> resample_init_arm;
 
         if (paramss["robot"] == "icub")
-            resample_init_arm = std::unique_ptr<InitiCubArm>(new InitiCubArm(paramss["cam_sel"], paramss["laterality"],
-                                                                             "handTracking/ResamplingWithPrior/InitiCubArm/" + paramss["cam_sel"]));
+            resample_init_arm = std::unique_ptr<InitiCubArm>(new InitiCubArm(paramss["laterality"], "handTracking/ResamplingWithPrior/InitiCubArm/" + paramss["cam_sel"]));
         else if (paramss["robot"] == "walkman")
-            resample_init_arm = std::unique_ptr<InitWalkmanArm>(new InitWalkmanArm(paramss["cam_sel"], paramss["laterality"],
-                                                                                   "handTracking/ResamplingWithPrior/InitWalkmanArm/" + paramss["cam_sel"]));
+            resample_init_arm = std::unique_ptr<InitWalkmanArm>(new InitWalkmanArm(paramss["laterality"], "handTracking/ResamplingWithPrior/InitWalkmanArm/" + paramss["cam_sel"]));
 
         pf_resampling = std::unique_ptr<Resampling>(new ResamplingWithPrior(std::move(resample_init_arm), paramsd["prior_ratio"]));
     }

--- a/src/hand-tracking/src/main.cpp
+++ b/src/hand-tracking/src/main.cpp
@@ -345,14 +345,14 @@ int main(int argc, char *argv[])
     }
 
     /* PARTICLE FILTER */
-    VisualSIS vsis_pf(paramss["cam_sel"],
+    VisualSIS vsis_pf(std::move(init_arm),
+                      std::move(pf_prediction),
+                      std::move(vpf_correction),
+                      std::move(pf_resampling),
+                      paramss["cam_sel"],
                       paramsd["num_particles"],
                       paramsd["resample_ratio"],
                       "handTracking/VisualSIS/" + paramss["cam_sel"]);
-    vsis_pf.setInitialization(std::move(init_arm));
-    vsis_pf.setPrediction(std::move(pf_prediction));
-    vsis_pf.setCorrection(std::move(vpf_correction));
-    vsis_pf.setResampling(std::move(pf_resampling));
 
 
     vsis_pf.boot();

--- a/src/hand-tracking/src/main.cpp
+++ b/src/hand-tracking/src/main.cpp
@@ -94,7 +94,8 @@ int main(int argc, char *argv[])
 
     /* Get Brownian Motion parameters */
     yarp::os::Bottle bottle_brownianmotion_params = rf.findGroup("BROWNIANMOTION");
-    paramsd["q_xy"]       = bottle_brownianmotion_params.check("q_xy",       Value(0.005)).asDouble();
+    paramsd["q_x"]        = bottle_brownianmotion_params.check("q_x",        Value(0.005)).asDouble();
+    paramsd["q_y"]        = bottle_brownianmotion_params.check("q_y",        Value(0.005)).asDouble();
     paramsd["q_z"]        = bottle_brownianmotion_params.check("q_z",        Value(0.005)).asDouble();
     paramsd["theta"]      = bottle_brownianmotion_params.check("theta",      Value(3.0)).asDouble();
     paramsd["cone_angle"] = bottle_brownianmotion_params.check("cone_angle", Value(2.5)).asDouble();
@@ -141,7 +142,8 @@ int main(int argc, char *argv[])
     yInfo() << log_ID << " - play:"           << (paramsd["play"] == 1.0 ? "true" : "false");
 
     yInfo() << log_ID << "Motion modle parameters:";
-    yInfo() << log_ID << " - q_xy:"       << paramsd["q_xy"];
+    yInfo() << log_ID << " - q_x:"        << paramsd["q_x"];
+    yInfo() << log_ID << " - q_y:"        << paramsd["q_y"];
     yInfo() << log_ID << " - q_z:"        << paramsd["q_z"];
     yInfo() << log_ID << " - theta:"      << paramsd["theta"];
     yInfo() << log_ID << " - cone_angle:" << paramsd["cone_angle"];
@@ -186,7 +188,7 @@ int main(int argc, char *argv[])
 
 
     /* MOTION MODEL */
-    std::unique_ptr<StateModel> brown(new BrownianMotionPose(paramsd["q_xy"], paramsd["q_z"], paramsd["theta"], paramsd["cone_angle"], paramsd["seed"]));
+    std::unique_ptr<StateModel> brown(new BrownianMotionPose(paramsd["q_x"], paramsd["q_y"], paramsd["q_z"], paramsd["theta"], paramsd["cone_angle"], paramsd["seed"]));
 
     std::unique_ptr<ExogenousModel> robot_motion;
     if (paramss["robot"] == "icub")

--- a/src/hand-tracking/src/utils.cpp
+++ b/src/hand-tracking/src/utils.cpp
@@ -40,3 +40,23 @@ VectorXd hand_tracking::utils::axis_angle_to_euler
                                                      axis_of_rotation_to_index(axis_2),
                                                      axis_of_rotation_to_index(axis_3));
 }
+
+
+VectorXd hand_tracking::utils::euler_to_axis_angle
+(
+    const Ref<const VectorXd>& euler_angles,
+    const AxisOfRotation axis_1,
+    const AxisOfRotation axis_2,
+    const AxisOfRotation axis_3
+)
+{
+    AngleAxisd angle_axis(AngleAxisd(euler_angles(0), axis_of_rotation_to_vector(axis_1)) *
+                          AngleAxisd(euler_angles(1), axis_of_rotation_to_vector(axis_2)) *
+                          AngleAxisd(euler_angles(2), axis_of_rotation_to_vector(axis_3)));
+
+    VectorXd axis_angle(4);
+    axis_angle.head<3>() = angle_axis.axis();
+    axis_angle(3) = angle_axis.angle();
+
+    return axis_angle;
+}

--- a/src/hand-tracking/src/utils.cpp
+++ b/src/hand-tracking/src/utils.cpp
@@ -1,0 +1,42 @@
+#include <utils.h>
+
+using namespace Eigen;
+using namespace hand_tracking::utils;
+
+
+std::size_t hand_tracking::utils::axis_of_rotation_to_index(const AxisOfRotation axis)
+{
+   if (axis == AxisOfRotation::UnitX)
+       return 0;
+   else if (axis == AxisOfRotation::UnitY)
+       return 1;
+   else if (axis == AxisOfRotation::UnitZ)
+       return 2;
+}
+
+
+Eigen::Vector3d hand_tracking::utils::axis_of_rotation_to_vector(const AxisOfRotation axis)
+{
+   if (axis == AxisOfRotation::UnitX)
+       return Vector3d::UnitX();
+   else if (axis == AxisOfRotation::UnitY)
+       return Vector3d::UnitY();
+   else if (axis == AxisOfRotation::UnitZ)
+       return Vector3d::UnitZ();
+}
+
+
+VectorXd hand_tracking::utils::axis_angle_to_euler
+(
+    const Ref<const VectorXd>& axis,
+    const double angle,
+    const AxisOfRotation axis_1,
+    const AxisOfRotation axis_2,
+    const AxisOfRotation axis_3
+)
+{
+    AngleAxisd angle_axis(angle, axis);
+    return angle_axis.toRotationMatrix().eulerAngles(axis_of_rotation_to_index(axis_1),
+                                                     axis_of_rotation_to_index(axis_2),
+                                                     axis_of_rotation_to_index(axis_3));
+}


### PR DESCRIPTION
Within this PR:
- Update required `Devel` version of `BayesFilters` library to `0.9.100` in `CMakeLists.txt` of module `hand-tracking`
- Use `double`, `Eigen::Vector*d` and `Eigen::Matrix*d` instead of `float`, `Eigen::Vector*f` and `Eigen::Matrix*f` in all the classes inheriting from `BayesFilters` library classes when required

#### Utilities
- Add utility `hand_tracking::utils::axis_angle_to_euler` to convert from axis/angle to a given Euler parametrization
- Add utility `hand_tracking::utils::euler_to_axis_angle` to convert from a given Euler parametrization to axis/angle

#### Class `BrownianMotionPose`
- Implement method `BrownianMotionPose::getOutputSize`
- Re-implement class `BrownianMotionPose` with Euler ZYX angles instead of axis/angle representation
- Add separate parameters `q_x`, `q_y` and `q_z` for standard deviation of the noise of the Cartesian part of the state vector

#### Class `DrawParticlesImportanceThreshold`
- Re-implement class `DrawParticlesImportanceThreshold` using `bfl::ParticleSet` and taking into account that `BayesFilters` uses particle weights in log space from version `0.8.0`

#### Class `GatePose`
- Re-implement class `GatePose` using `bfl::ParticleSet` and taking into account that `BayesFilters` uses particle weights in log space from version `0.8.0`
- Convert from ZYX Euler angles to axis/angle in `GatePose::correctStep` since methods `GatePose::isInsideCone` and `GatePose::isWithinRotation` assume that the state is represented using axis/angle

#### Class `InitPoseParticles`
- Reimplement `InitPoseParticles::initialize` using `bfl::ParticleSet` and taking into account that `BayesFilters` uses particle weights in log space from version `0.8.0`

#### Class `InitPoseParticlesAxisAngle`
- Implement class `InitPoseParticlesAxisAngle` inheriting from `InitPoseParticles` that allows an easy interface to particles initialization classes that obtain axis/angle poses from iCub/Walkman libraries

#### Class `InitiCubArm`
- Remove useless argument `cam_sel` in argument of ctor `InitiCubArm::InitiCubArm`
- This class now inherits from class `InitPoseParticlesAxisAngle`

#### Class `InitWalkmanArm`
- Remove useless argument `cam_sel` in argument of ctor `InitWalkmanArm::InitWalkmanArm`
- This class now inherits from class `InitPoseParticlesAxisAngle`

#### Class `KinPoseModel`
- Implement method `KinPoseModel::getOutputSize`
- Re-implement class `KinPoseModel` with Euler ZYX angles instead of axis/angle representation

#### Class `KinPoseModelAxisAngle`
- Implement class `KinPoseModelAxisAngle` inheriting from `KinPoseModel` that allows an easy interface to forward kinematic classes that obtain axis/angle poses from iCub/Walkman libraries

#### Class `iCubFwdKinModel`
- This class now inherits from `KinPoseModelAxisAngle`

#### Class `PlayiCubFwdKinModel`
- This class now inherits from `KinPoseModelAxisAngle`

##### Class `PlayWalkmanPoseModel`
- This class now inherits from `KinPoseModelAxisAngle`

#### Class `iCubArmModel`
-  Convert from Euler ZYX to axis/angle in method `iCubArmModel::getModelPose` since `SuperimposeMeshLib` uses poses with orientation expressed using axis/angle

#### Class `WalkmanArmModel`
-  Convert from Euler ZYX to axis/angle in method `WalkmanArmModel::getModelPose` since `SuperimposeMeshLib` uses poses with orientation expressed using axis/angle

#### Class `iCubCamera`
- Use `yarp::cv::toCvMat` instead of deprecated `yarp::sig::Image::getIplImage()` in `iCubCamera::bufferData`

#### Class `WalkmanCamera`
- Use `yarp::cv::toCvMat` instead of deprecated `yarp::sig::Image::getIplImage()` in `WalkmanCamera::bufferData`

#### Likelihoods
- Change all the likelihoods in order to use the method `bfl::MeasurementModel::measure` instead of removed method `bfl::MeasurementModel::getAgentMeasurements`

#### Class `VisualProprioception`
- Implement method `VisualProprioception::getOutputSize`
- Re-implement class `VisualProprioception` (both cpu and gpu implementation) to comply with the new measurement paradigm introduced from `BayesFilters` `0.8.0`

#### Class `VisualSIS`
- Re-implement class `VisualSIS` 
   - using `bfl::ParticleSet`, 
   - using particle weights in log space
   - taking into account the new interface of `bfl::ParticleFilter` ctor
   - taking into account the new size of the state vector (three Cartesian coordinates and three Euler angles)
   - converting the state vector to axis/angle representation before sending the estimate to the output port since the rest of the hand tracking pipeline assumes that representation

#### Configuration file of module `hand-tracking`
- Remove parameter `q_xy` and added parameters `q_x` and `q_y`
- Remove parameters `theta` and `cone_angle`
- Add parameters `q_phi`, `q_theta` and `q_psi` for standard deviation of the noise of the ZYX Euler angles

#### Main file of module `hand-tracking` (`src/hand-tracking/src/main.cpp`)
- Use renamed class `bfl::BootstrapCorrection` instead of `bfl::UpdateParticles` while instantiating the particle filter correction class
- Update code according to new ctor of classes `InitiCubArm` and `InitWalkmanArm`
- Update code according to the new structure of the configuration file

#### Readme.md
- Update the minimum required version of `BayesFilters` library in `README.md`

#### CMakeLists.txt
- Fix indentation issues in `src/hand-tracking/CMakeLists.txt`

Closes hsp-iit/workbook-nicola-piga#56, hsp-iit/workbook-nicola-piga#57