### PR TITLE
Fix missing initialization and update of fingers 'ring' and 'little' in class iCubArmModel

### DIFF
--- a/src/hand-tracking/src/iCubArmModel.cpp
+++ b/src/hand-tracking/src/iCubArmModel.cpp
@@ -352,7 +352,7 @@ bool iCubArmModel::setArmJoints(const Vector& q)
     icub_arm_.setAng(q.subVector(0, 9) * CTRL_DEG2RAD);
 
     Vector chainjoints;
-    for (size_t i = 0; i < 3; ++i)
+    for (size_t i = 0; i < 5; ++i)
     {
         if (!icub_kin_finger_[i].getChainJoints(q.subVector(3, 18), chainjoints))
             return false;

--- a/src/hand-tracking/src/iCubArmModel.cpp
+++ b/src/hand-tracking/src/iCubArmModel.cpp
@@ -144,6 +144,8 @@ iCubArmModel::iCubArmModel(const bool use_thumb,
     icub_kin_finger_[0].setAllConstraints(false);
     icub_kin_finger_[1].setAllConstraints(false);
     icub_kin_finger_[2].setAllConstraints(false);
+    icub_kin_finger_[3].setAllConstraints(false);
+    icub_kin_finger_[4].setAllConstraints(false);
 
     icub_arm_.setAllConstraints(false);
     icub_arm_.releaseLink(0);


### PR DESCRIPTION
This PR fix two issues within class `iCubArmModel`:
- missing initialization of constraints of fingers `ring` and `little` in constructor of class `iCubArmModel`
- missing update of encoders of fingers `ring` and `little` in method `iCubArmModel::setArmJoints`