### PR TITLE
Fix missing return paths in hand-tracking utils

### DIFF
--- a/src/hand-tracking/src/cpu/KLD.cpp
+++ b/src/hand-tracking/src/cpu/KLD.cpp
@@ -35,5 +35,5 @@ KLD::~KLD() noexcept
 
 std::pair<bool, VectorXd> KLD::likelihood(const MeasurementModel& measurement_model, const Ref<const MatrixXd>& pred_states)
 {
-    throw std::runtime_error("[KLD][CPU] Unimplemented.");
+    throw std::runtime_error("ERROR::KLD::LIKELIHOOD\nERROR: Unimplemented.");
 }

--- a/src/hand-tracking/src/cpu/NormTwoKLD.cpp
+++ b/src/hand-tracking/src/cpu/NormTwoKLD.cpp
@@ -35,5 +35,5 @@ NormTwoKLD::~NormTwoKLD() noexcept
 
 std::pair<bool, VectorXd> NormTwoKLD::likelihood(const MeasurementModel& measurement_model, const Ref<const MatrixXd>& pred_states)
 {
-    throw std::runtime_error("[NormTwoKLD][CPU] Unimplemented.");
+    throw std::runtime_error("ERROR::NORMTWOKLD::LIKELIHOOD\nERROR: Unimplemented.");
 }

--- a/src/hand-tracking/src/cpu/NormTwoKLDChiSquare.cpp
+++ b/src/hand-tracking/src/cpu/NormTwoKLDChiSquare.cpp
@@ -35,5 +35,5 @@ NormTwoKLDChiSquare::~NormTwoKLDChiSquare() noexcept
 
 std::pair<bool, VectorXd> NormTwoKLDChiSquare::likelihood(const MeasurementModel& measurement_model, const Ref<const MatrixXd>& pred_states)
 {
-    throw std::runtime_error("[NormTwoKLDChiSquare][CPU] Unimplemented.");
+    throw std::runtime_error("ERROR::NORMTWOKLDCHISQUARE::LIKELIHOOD\nERROR: Unimplemented.");
 }

--- a/src/hand-tracking/src/utils.cpp
+++ b/src/hand-tracking/src/utils.cpp
@@ -1,5 +1,7 @@
 #include <utils.h>
 
+#include <exception>
+
 using namespace Eigen;
 using namespace hand_tracking::utils;
 
@@ -12,6 +14,8 @@ std::size_t hand_tracking::utils::axis_of_rotation_to_index(const AxisOfRotation
        return 1;
    else if (axis == AxisOfRotation::UnitZ)
        return 2;
+
+   throw std::runtime_error("ERROR::UTILS::AXIS_OF_ROTATION_TO_INDEX\nERROR: Wrong input value of enum class type hand_tracking::utils::AxisOfRotation.");
 }
 
 
@@ -23,6 +27,8 @@ Eigen::Vector3d hand_tracking::utils::axis_of_rotation_to_vector(const AxisOfRot
        return Vector3d::UnitY();
    else if (axis == AxisOfRotation::UnitZ)
        return Vector3d::UnitZ();
+
+   throw std::runtime_error("ERROR::UTILS::AXIS_OF_ROTATION_TO_VECTOR\nERROR: Wrong input value of enum class type hand_tracking::utils::AxisOfRotation.");
 }
 
 


### PR DESCRIPTION
This PR fixes missing return statements in hand-tracking/src/utils.cpp file and, in particular, to the `hand_tracking::utils::axis_of_rotation_to_index` and `hand_tracking::utils::axis_of_rotation_to_vector`. However, since the functions accept as imput an `enum class` and provide a different output based on the input value, in the case of a wrong input (which is possible if the develope is evil) an exception is thrown.

As a plus, I also standardized the throw error messages throughout the code.