### PR TITLE
Fix missing YARP::YARP_cv dependency in CMakeLists.txt of module hand-tracking

### DIFF
--- a/src/hand-tracking/CMakeLists.txt
+++ b/src/hand-tracking/CMakeLists.txt
@@ -15,6 +15,7 @@ find_package(YARP CONFIG REQUIRED
                  sig
                  eigen
                  gsl
+                 cv
 )
 
 find_package(ICUB REQUIRED)
@@ -270,6 +271,7 @@ target_link_libraries(${EXE_TARGET_NAME}
                           YARP::YARP_sig
                           YARP::YARP_eigen
                           YARP::YARP_gsl
+                          YARP::YARP_cv
 )
 
 if(BFL_CUDA)


### PR DESCRIPTION
This PR adds a missing dependency, namely `YARP::YARP_cv`, in the `CMakeLists.txt` of module `hand-tracking`.